### PR TITLE
respa_exchange: Implement heuristics for determining the real organizer name

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -261,6 +261,10 @@ class ResourceSerializer(TranslatedModelSerializer, munigeo_api.GeoModelSerializ
             rv_list = get_resource_reservations_queryset(self.context['start'], self.context['end'])
             rv_list = rv_list.filter(resource=obj)
 
+        rv_list = list(rv_list)
+        if not rv_list:
+            return []
+
         rv_ser_list = ReservationSerializer(rv_list, many=True, context=self.context).data
         return rv_ser_list
 

--- a/respa_exchange/downloader.py
+++ b/respa_exchange/downloader.py
@@ -62,7 +62,7 @@ def _populate_reservation(reservation, ex_resource, item_props, ex_reservation=N
         reservation.reserver_name = name or ''
         reservation.host_name = reservation.reserver_name
     else:
-        reserver_name = item_props.get('reserver_name', None) or ''
+        reserver_name = item_props.get('reserver_name') or ''
         reservation.reserver_name = reserver_name
         reservation.host_name = reserver_name
 
@@ -352,6 +352,8 @@ def sync_from_exchange(ex_resource, future_days=365, no_op=False):
     )
 
     if no_op:
+        with configure_scope() as scope:
+            scope.remove_extra('resource')
         return
 
     # First handle deletions . . .

--- a/respa_exchange/downloader.py
+++ b/respa_exchange/downloader.py
@@ -34,24 +34,30 @@ def _populate_reservation(reservation, ex_resource, item_props):
     :type item_props: dict
     :return:
     """
-    reservation.begin = item_props["start"]
-    reservation.end = item_props["end"]
-    subject = item_props["subject"]
+    reservation.begin = item_props['start']
+    reservation.end = item_props['end']
+    subject = item_props['subject']
     if subject is None:
         with push_scope() as scope:
             scope.level = 'warning'
-            capture_message('Calendar item has empty subject')
+            capture_message("Calendar item has empty subject")
         subject = ''
-    reservation.event_subject = item_props["subject"]
-    organizer = item_props.get("organizer")
-    if organizer:
+    reservation.event_subject = item_props['subject']
+
+    organizer = item_props.get('organizer')
+    if organizer is not None:
         reservation.reserver_email_address = organizer.email_address
         if organizer.given_name and organizer.surname:
-            name = "%s %s" % (organizer.given_name, organizer.surname)
+            name = '%s %s' % (organizer.given_name, organizer.surname)
         else:
             name = organizer.name
-        reservation.reserver_name = name or ""
+        reservation.reserver_name = name or ''
         reservation.host_name = reservation.reserver_name
+    else:
+        reserver_name = item_props.get('reserver_name', None) or ''
+        reservation.reserver_name = reserver_name
+        reservation.host_name = reserver_name
+
     comment_text = "Synchronized from Exchange %s" % ex_resource.exchange
     reservation.comments = comment_text
     reservation._from_exchange = True  # Set a flag to prevent immediate re-upload
@@ -88,7 +94,7 @@ def _create_reservation_from_exchange(item_id, ex_resource, item_props):
     return ex_reservation
 
 
-def _determine_organizer(ex_resource, calendar_item, organizer):
+def _find_exchange_user_by_mailbox(ex_resource, mailbox, last_updated_at=None):
     """Try to find the ExchangeUser entry matching the organizer XML element
 
     Matching is attempted based on the organizer's email address and
@@ -96,7 +102,6 @@ def _determine_organizer(ex_resource, calendar_item, organizer):
     is sent and the ExchangeUser model is updated based on the response.
     """
 
-    mailbox = organizer.find("t:Mailbox", namespaces=NAMESPACES)
     routing_type = mailbox.find("t:RoutingType", namespaces=NAMESPACES).text
     user_identifier = mailbox.find("t:EmailAddress", namespaces=NAMESPACES).text
     user_name = mailbox.find("t:Name", namespaces=NAMESPACES)
@@ -129,9 +134,8 @@ def _determine_organizer(ex_resource, calendar_item, organizer):
         # If the user name does not match, but we have updated
         # the user info after the calendar item was created,
         # everything is fine.
-        item_updated_at = calendar_item.get('updated_at')
-        if item_updated_at and ex_user.updated_at:
-            if ex_user.updated_at > item_updated_at:
+        if last_updated_at and ex_user.updated_at:
+            if ex_user.updated_at > last_updated_at:
                 return ex_user
 
     req = ResolveNamesRequest([user_identifier], principal=ex_resource.principal_email)
@@ -209,30 +213,65 @@ def _determine_organizer(ex_resource, calendar_item, organizer):
     return ex_user
 
 
-def _parse_item_props(ex_resource, item_id, item):
+def _determine_organizer(ex_resource, calendar_item):
+    item_updated_at = calendar_item.get('updated_at')
+    organizer = calendar_item.find('t:Organizer', namespaces=NAMESPACES)
+    if organizer is None:
+        return None
+
+    mailbox = organizer.find('t:Mailbox', namespaces=NAMESPACES)
+    ex_user = _find_exchange_user_by_mailbox(ex_resource, mailbox, item_updated_at)
+    if ex_user is None:
+        return None
+
+    if ex_user.email_address.lower() == ex_resource.principal_email.lower():
+        # Sometimes the reservation appears to be made by the resource
+        # itself. We do a bit of heuristics to try to determine the actual
+        # organizer.
+        required_attendees = calendar_item.find('t:RequiredAttendees', namespaces=NAMESPACES)
+        if required_attendees is None:
+            return None
+        first_attendee = required_attendees.find('t:Attendee', namespaces=NAMESPACES)
+        if first_attendee is None:
+            return None
+        mailbox = first_attendee.find('t:Mailbox', namespaces=NAMESPACES)
+        ex_user = _find_exchange_user_by_mailbox(ex_resource, mailbox, item_updated_at)
+
+    return ex_user
+
+
+def _parse_item_props(ex_resource, item):
     item_props = dict(
-        start=iso8601.parse_date(item.find("t:Start", namespaces=NAMESPACES).text),
-        end=iso8601.parse_date(item.find("t:End", namespaces=NAMESPACES).text),
-        subject=item.find("t:Subject", namespaces=NAMESPACES).text,
+        start=iso8601.parse_date(item.find('t:Start', namespaces=NAMESPACES).text),
+        end=iso8601.parse_date(item.find('t:End', namespaces=NAMESPACES).text),
+        subject=item.find('t:Subject', namespaces=NAMESPACES).text,
     )
 
     item_props['updated_at'] = None
-    el = item.find("t:LastModifiedTime", namespaces=NAMESPACES)
+    el = item.find('t:LastModifiedTime', namespaces=NAMESPACES)
     if el is not None:
         if el.text:
             item_props['updated_at'] = iso8601.parse_date(el.text)
 
-    organizer = item.find("t:Organizer", namespaces=NAMESPACES)
-    if organizer is not None:
-        organizer = _determine_organizer(ex_resource, item_props, organizer)
+    organizer = _determine_organizer(ex_resource, item)
+    if organizer is None:
+        # The DisplayTo field appears to usually (?) contain the
+        # name of the reserver.
+        reserver_name = None
+        display_to = item.find('t:DisplayTo', namespaces=NAMESPACES)
+        if display_to is not None:
+            reserver_name = display_to.text
+            if ';' in reserver_name:
+                reserver_name = None
 
-    item_props["organizer"] = organizer
+    item_props['organizer'] = organizer
+
     # Subjects often start with the organizer name, so we strip it
-    if organizer and organizer.name:
-        s = organizer.name + " "
-        subject = item_props["subject"]
+    if organizer is not None and organizer.name:
+        s = organizer.name + ' '
+        subject = item_props['subject']
         if subject and subject.startswith(s):
-            item_props["subject"] = subject[len(s):]
+            item_props['subject'] = subject[len(s):]
 
     return item_props
 
@@ -246,7 +285,7 @@ def fetch_reservation_data(ex_reservation):
     session = ex_reservation.exchange.get_ews_session()
     items = [item for item in gcir.send(session)]
     assert len(items) == 1, "Exchange returned %d items instead of 1" % (len(items))
-    return str(etree.tostring(items[0], pretty_print=True), encoding='utf8')
+    return items[0]
 
 
 @atomic
@@ -325,7 +364,7 @@ def sync_from_exchange(ex_resource, future_days=365, no_op=False):
 
             ex_reservation = extant_exchange_reservations.get(item_id.hash)
 
-            item_props = _parse_item_props(ex_resource, item_id, item)
+            item_props = _parse_item_props(ex_resource, item)
 
             if not ex_reservation:  # It's a new one!
                 ex_reservation = _create_reservation_from_exchange(item_id, ex_resource, item_props)

--- a/respa_exchange/downloader.py
+++ b/respa_exchange/downloader.py
@@ -291,6 +291,9 @@ def fetch_reservation_data(ex_reservation):
     )
     session = ex_reservation.exchange.get_ews_session()
     items = [item for item in gcir.send(session)]
+    if len(items) == 0:
+        return None
+
     assert len(items) == 1, "Exchange returned %d items instead of 1" % (len(items))
     return items[0]
 

--- a/respa_exchange/signals.py
+++ b/respa_exchange/signals.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db import transaction
 
 from respa_exchange.models import ExchangeReservation, ExchangeResource
 from respa_exchange.uploader import create_on_remote, delete_on_remote, update_on_remote
@@ -21,29 +22,29 @@ def handle_reservation_save(instance, **kwargs):
         # we don't want to push it back up!
         return
 
-    exchange_reservation = ExchangeReservation.objects.filter(
-        reservation=instance,
-        # If this reservation has come from Exchange,
-        # we don't want to upload changes made to it.
-        managed_in_exchange=False
-    ).first()
-    if not exchange_reservation:  # First sync? How exciting!
+    with transaction.atomic():
         exchange_resource = ExchangeResource.objects.filter(
             sync_from_respa=True, resource=instance.resource
-        ).select_related("exchange").first()
-
+        ).select_for_update().select_related("exchange").first()
         if not exchange_resource:  # Not an Exchange-enabled resource; never mind.
             return
 
-        exchange_reservation = ExchangeReservation(
+        exchange_reservation = ExchangeReservation.objects.filter(
             reservation=instance,
-            exchange=exchange_resource.exchange,
-            principal_email=exchange_resource.principal_email
-        )
+            # If this reservation has come from Exchange,
+            # we don't want to upload changes made to it.
+            managed_in_exchange=False
+        ).first()
+        if not exchange_reservation:  # First sync? How exciting!
+            exchange_reservation = ExchangeReservation(
+                reservation=instance,
+                exchange=exchange_resource.exchange,
+                principal_email=exchange_resource.principal_email
+            )
 
-        create_on_remote(exchange_reservation)
-    else:
-        update_on_remote(exchange_reservation)
+            create_on_remote(exchange_reservation)
+        else:
+            update_on_remote(exchange_reservation)
 
 
 def handle_reservation_delete(instance, **kwargs):
@@ -58,12 +59,19 @@ def handle_reservation_delete(instance, **kwargs):
     if not getattr(settings, "RESPA_EXCHANGE_ENABLED", True):
         return
 
-    exchange_reservation = ExchangeReservation.objects.filter(
-        reservation=instance,
-        # If this reservation has come from Exchange,
-        # we don't want to upload deletions.
-        managed_in_exchange=False
-    ).first()
-    if exchange_reservation:
-        delete_on_remote(exchange_reservation)
-        assert not exchange_reservation.pk
+    with transaction.atomic():
+        exchange_resource = ExchangeResource.objects.filter(
+            sync_from_respa=True, resource=instance.resource
+        ).select_for_update().select_related("exchange").first()
+        if not exchange_resource:  # Not an Exchange-enabled resource; never mind.
+            return
+
+        exchange_reservation = ExchangeReservation.objects.filter(
+            reservation=instance,
+            # If this reservation has come from Exchange,
+            # we don't want to upload deletions.
+            managed_in_exchange=False
+        ).first()
+        if exchange_reservation:
+            delete_on_remote(exchange_reservation)
+            assert not exchange_reservation.pk


### PR DESCRIPTION
Sometimes Exchange sets the Organizer element to point to the resource mailbox. In these cases, we need to resort to heuristics to figure out who really made the reservation.

If the event has required attendees, we choose the first attendee as the host. If not, we use the DisplayTo field as the reserver name.