### PR TITLE
Merge City-of-Helsinki master (update to tag 0.4.1)

### DIFF
--- a/respa_admin/webpack.config.js
+++ b/respa_admin/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
       {
         test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
         use: [{
-        loader: 'file-loader',
+          loader: 'file-loader',
           options: {
             name: '[name].[ext]',
             outputPath: 'fonts/'
@@ -44,7 +44,14 @@ module.exports = {
       chunkFilename: "[id].css"
     }),
     new CopyPlugin([
-      { from: './static_src/img/', to: './img/'}
+      { from: './static_src/img/', to: './img/' }
     ])
-  ]
+  ],
+  resolve: {
+    alias: {
+      // For some reason there are multiple jQuery versions, leading to datepicker events not working properly
+      // added this to force all modules to use the same jQuery version
+      'jquery': path.join(__dirname, 'node_modules/jquery/src/jquery')
+    }
+  }
 };


### PR DESCRIPTION
Merge upstream changes until release tag [0.4.1 ](https://github.com/City-of-Helsinki/respa/releases/tag/v0.4.1)from City of Helsinki. This includes the following hotfix:

- Regression in Respa Admin opening hour editor has been fixed.

Refs TAM-24