### PR TITLE
Fix bug when syncing resources to the exchange

### DIFF
--- a/respa_exchange/downloader.py
+++ b/respa_exchange/downloader.py
@@ -320,8 +320,11 @@ def sync_from_exchange(ex_resource, future_days=365, no_op=False):
     """
 
     # To avoid race conditions with the Respa API processes, we lock the
-    # resource on database level before starting sync.
-    ex_resource = ExchangeResource.objects.select_for_update().get(id=ex_resource.id)
+    # resource on database level before starting sync. In case when syncing
+    # resource on creation, we cant select for update, because there is not
+    # that resource yet in the database.
+    if ex_resource.id:
+        ex_resource = ExchangeResource.objects.select_for_update().get(id=ex_resource.id)
 
     if not ex_resource.sync_to_respa and not no_op:
         return


### PR DESCRIPTION
When creating new resource as a admin to the respa, the exchange syncing
does not work properly. System is syncing the resource to the exchange
before the resource is saved to the database and the sync function wants
to lock the resource in the database before doing it. This pattern
creates problem when the resource does not have any id, but at case of
the new resource we don't need to lock the database resource.

Fixing the problem with conditionally locking the database resource,
meaning that if the given instance does not have id, we skip the
database lock.