### PR TITLE
Don't use IPv6 for Exchange even if it is available

### DIFF
--- a/respa_exchange/ews/session.py
+++ b/respa_exchange/ews/session.py
@@ -5,10 +5,16 @@ from lxml import etree
 from requests.packages.urllib3.util.retry import Retry
 from requests.auth import HTTPBasicAuth
 from requests.adapters import HTTPAdapter
+import socket
+import requests.packages.urllib3.util.connection as urllib3_cn
 
 from .xml import NAMESPACES
 
 SOAP_ENVELOPE_TAG = b'<Envelope xmlns="http://schemas.xmlsoap.org/soap/envelope/">'
+
+
+def force_ipv4():
+    urllib3_cn.allowed_gai_family = lambda: socket.AF_INET
 
 
 class SoapFault(Exception):
@@ -42,6 +48,7 @@ class ExchangeSession(requests.Session):
     encoding = "UTF-8"
 
     def __init__(self, url, username, password):
+        force_ipv4()  # O365 Exchange has an allowlist of IPv4 addresses, if we use IPv6 we will get blocked
         super(ExchangeSession, self).__init__()
         self.url = url
         self.auth = HTTPBasicAuth(username, password)


### PR DESCRIPTION
The cloud O365 Exchange has an allowlist of IP addresses that are allowed to use "legacy authentication" (such as the Basic Auth we are using). That allowlist only supports IPv4 addresses. Normally requests uses IPv6 if it detects that the infrastucture supports IPv6, which our production environment does. So currently our requests in production are getting blocked by that allowlist because we are sending requests from an IPv6 address.

This change attempts to force our requests to always use IPv4, even when IPv6 would be available. Unfortunately there is no another environment where IPv6 would be supported, so this is completely untested and based on hearsay that it might work. At least it does not break IPv4 requests.

Sources:
https://stackoverflow.com/a/46972341
https://pythonadventures.wordpress.com/2019/06/28/force-requests-to-use-ipv4/