### PR TITLE
Implement data changes for Helsingin työllisyyspalvelut

### DIFF
--- a/resources/migrations/0067_data_htp_group_changes.py
+++ b/resources/migrations/0067_data_htp_group_changes.py
@@ -1,0 +1,97 @@
+import logging
+
+from django.db import migrations
+from django.db.models import Q
+
+logger = logging.getLogger(__name__)
+
+EXTRA_DESCRIPTION = "Näitä tiloja voidaan varata vain Työllisyyspalveluiden käyttöön."
+GROUP_ID_HTP = 9
+GROUP_ID_KANSLIA = 2
+
+
+def get_groups(ResourceGroup):
+    return (
+        ResourceGroup.objects.get(id=GROUP_ID_HTP, name="Helsingin työllisyyspalvelut"),
+        ResourceGroup.objects.get(id=GROUP_ID_KANSLIA, name="Kanslia"),
+    )
+
+
+def get_models(apps):
+    return (
+        apps.get_model("resources", "Resource"),
+        apps.get_model("resources", "ResourceGroup"),
+    )
+
+
+def backward(apps, schema_editor):
+    Resource, ResourceGroup = get_models(apps)
+    try:
+        # Make sure that resource groups exist.
+        _, kanslia = get_groups(ResourceGroup)
+    except ResourceGroup.DoesNotExist:
+        logger.warn("Unable to find resource group for Kanslia or HTP.")
+        return
+
+    qs = (
+        Resource.objects
+        .filter(
+            Q(description__startswith=EXTRA_DESCRIPTION)
+            | Q(description_fi__startswith=EXTRA_DESCRIPTION)
+        )
+        .filter(groups__id__in=[kanslia.id])
+    )
+
+    for resource in qs:
+        for field in ("description", "description_fi"):
+            value = getattr(resource, field)
+            if value.startswith(EXTRA_DESCRIPTION):
+                setattr(resource, field, value[len(EXTRA_DESCRIPTION)].lstrip())
+
+        resource.groups.remove(kanslia)
+        resource.save()
+
+
+def forward(apps, schema_editor):
+    Resource, ResourceGroup = get_models(apps)
+    try:
+        # Make sure that resource groups exist.
+        htp, kanslia = get_groups(ResourceGroup)
+    except ResourceGroup.DoesNotExist:
+        logger.warn("Unable to find resource group for Kanslia or HTP.")
+        return
+
+    qs = (
+        Resource.objects
+        .filter(groups__id__in=[htp.id])
+        .exclude(groups__id__in=[kanslia.id])
+    )
+
+    for resource in qs:
+        for field in ("description", "description_fi"):
+            value = getattr(resource, field)
+            if not value.startswith(EXTRA_DESCRIPTION):
+                setattr(
+                    resource,
+                    field,
+                    EXTRA_DESCRIPTION + (" " if value else "") + value,
+                )
+
+        resource.groups.add(kanslia)
+        resource.save()
+
+
+class Migration(migrations.Migration):
+    """
+    Add resources in _Helsingin työllisyyspalvelut_ group to _Kanslia_ group.
+
+    In addition to that, prepend the description with a notice (`EXTRA_DESCRIPTION`).
+    """
+
+    dependencies = [
+        ("resources", "0066_support_for_django_2"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, backward),
+    ]

--- a/resources/migrations/0068_data_htp_add_unit_prefix.py
+++ b/resources/migrations/0068_data_htp_add_unit_prefix.py
@@ -1,0 +1,94 @@
+import logging
+
+from django.db import migrations
+from django.db.models import Q
+
+logger = logging.getLogger(__name__)
+
+GROUP_ID_HTP = 9
+GROUP_ID_KANSLIA = 2
+UNIT_NAME_PREFIX = "Työllisyyspalvelut / "
+
+
+def get_groups(ResourceGroup):
+    return (
+        ResourceGroup.objects.get(id=GROUP_ID_HTP, name="Helsingin työllisyyspalvelut"),
+        ResourceGroup.objects.get(id=GROUP_ID_KANSLIA, name="Kanslia"),
+    )
+
+
+def get_models(apps):
+    return (
+        apps.get_model("resources", "Resource"),
+        apps.get_model("resources", "ResourceGroup"),
+        apps.get_model("resources", "Unit"),
+    )
+
+
+def backward(apps, schema_editor):
+    Resource, ResourceGroup, Unit = get_models(apps)
+    try:
+        # Make sure that resource groups exist.
+        get_groups(ResourceGroup)
+    except ResourceGroup.DoesNotExist:
+        logger.warn("Unable to find resource group for Kanslia or HTP.")
+        return
+
+    units_qs = (
+        Unit.objects
+        .filter(
+            Q(name__startswith=UNIT_NAME_PREFIX)
+            | Q(name_fi__startswith=UNIT_NAME_PREFIX)
+        )
+    )
+
+    for unit in units_qs:
+        for field in ("name", "name_fi"):
+            value = getattr(unit, field)
+            if value.startswith(UNIT_NAME_PREFIX):
+                setattr(unit, field, value[len(UNIT_NAME_PREFIX) :])
+        unit.save()
+
+
+def forward(apps, schema_editor):
+    Resource, ResourceGroup, Unit = get_models(apps)
+    try:
+        # Make sure that resource groups exist.
+        htp, kanslia = get_groups(ResourceGroup)
+    except ResourceGroup.DoesNotExist:
+        logger.warn("Unable to find resource group for Kanslia or HTP.")
+        return
+
+    resource_id_qs = (
+        Resource.objects
+        .filter(groups__id__in=[htp.id])
+        .filter(groups__id__in=[kanslia.id])
+        .values_list("unit__id", flat=True)
+    )
+    units_qs = (
+        Unit.objects
+        .filter(id__in=resource_id_qs)
+    )
+
+    for unit in units_qs:
+        for field in ("name", "name_fi"):
+            value = getattr(unit, field)
+            if value and not value.startswith(UNIT_NAME_PREFIX):
+                setattr(unit, field, UNIT_NAME_PREFIX + value)
+        unit.save()
+
+
+class Migration(migrations.Migration):
+    """
+    For units that have resources belonging to both _Kanslia_ group and
+    _Helsingin työllisyyspalvelut_ groups, prefix the name of the unit
+    with `UNIT_NAME_PREFIX`.
+    """
+
+    dependencies = [
+        ("resources", "0067_data_htp_group_changes"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, backward),
+    ]

--- a/resources/migrations/0069_data_htp_add_metadataset.py
+++ b/resources/migrations/0069_data_htp_add_metadataset.py
@@ -1,0 +1,109 @@
+import logging
+
+from django.db import migrations
+from django.db.models import Q
+
+logger = logging.getLogger(__name__)
+
+GROUP_ID_HTP = 9
+GROUP_ID_KANSLIA = 2
+METADATASET_NAME = "Helsingin työllisyyspalvelut"
+
+
+def get_groups(ResourceGroup):
+    return (
+        ResourceGroup.objects.get(id=GROUP_ID_HTP, name="Helsingin työllisyyspalvelut"),
+        ResourceGroup.objects.get(id=GROUP_ID_KANSLIA, name="Kanslia"),
+    )
+
+
+def get_metadataset(apps, create):
+    ReservationMetadataSet = apps.get_model("resources", "ReservationMetadataSet")
+
+    if not create:
+        return ReservationMetadataSet.objects.filter(name=METADATASET_NAME).first()
+
+    metadataset, created = ReservationMetadataSet.objects.get_or_create(
+        name=METADATASET_NAME
+    )
+    if created:
+        # Fields copied from _Kanslia_ metadata set.
+        required_fields = (
+            "event_subject",
+            "reserver_name",
+        )
+        supported_fields = (
+            "event_description",
+            "event_subject",
+            "host_name",
+            "number_of_participants",
+            "participants",
+            "reserver_email_address",
+            "reserver_name",
+            "reserver_phone_number",
+        )
+
+        Field = apps.get_model("resources", "ReservationMetadataField")
+        metadataset.required_fields.add(
+            *Field.objects.filter(field_name__in=required_fields)
+        )
+        metadataset.supported_fields.add(
+            *Field.objects.filter(field_name__in=supported_fields)
+        )
+
+    return metadataset
+
+
+def get_models(apps):
+    return (
+        apps.get_model("resources", "Resource"),
+        apps.get_model("resources", "ResourceGroup"),
+    )
+
+
+def backward(apps, schema_editor):
+    Resource, ResourceGroup = get_models(apps)
+    try:
+        # Make sure that resource groups exist.
+        htp, kanslia = get_groups(ResourceGroup)
+    except ResourceGroup.DoesNotExist:
+        logger.warn("Unable to find resource group for Kanslia or HTP.")
+        return
+
+    metadataset = get_metadataset(apps, create=False)
+    if not metadataset:
+        # Nothing to do.
+        return
+
+    Resource.objects.filter(groups__id__in=[htp.id]).filter(
+        reservation_metadata_set_id=metadataset.id
+    ).update(reservation_metadata_set_id=None)
+
+
+def forward(apps, schema_editor):
+    Resource, ResourceGroup = get_models(apps)
+    try:
+        # Make sure that resource groups exist.
+        htp, kanslia = get_groups(ResourceGroup)
+    except ResourceGroup.DoesNotExist:
+        logger.warn("Unable to find resource group for Kanslia or HTP.")
+        return
+
+    metadataset = get_metadataset(apps, create=True)
+    Resource.objects.filter(groups__id__in=[htp.id]).filter(
+        reservation_metadata_set__isnull=True
+    ).update(reservation_metadata_set_id=metadataset.id)
+
+
+class Migration(migrations.Migration):
+    """
+    Create a new reservation metadata set for Helsingin työllisyyspalvelut.
+    """
+
+    dependencies = [
+        ("resources", "0068_data_htp_add_unit_prefix"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, backward),
+    ]


### PR DESCRIPTION
These migrations
  * add resources in _Helsingin työllisyyspalvelut_ group to _Kanslia_ group,
  * prepend a description to the said resources, and
  * prefix the names of the containing units with "Työllisyyspalvelut".