### PR TITLE
Allow 5-minute granularity for non-30-minute reservations

### DIFF
--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -315,7 +315,14 @@ class Reservation(ModifiableModel):
                 None,
             )
             if day:
-                slot_duration = self.resource.min_period
+                # If resource's minimum reservable time slot (min_period) matches the
+                # configured default time slot duration, validate that the reservation
+                # conforms to that granularity. Otherwise enforce granularity of 5mins.
+                default_duration = settings.RESPA_RESOURCE_DEFAULT_TIME_SLOT_DURATION
+                if self.resource.min_period == default_duration:
+                    slot_duration = default_duration
+                else:
+                    slot_duration = datetime.timedelta(minutes=5)
                 if not is_valid_time_slot(dt, slot_duration, day['opens']):
                     raise ValidationError(_("Begin and end time must match time slots"))
 

--- a/respa/settings.py
+++ b/respa/settings.py
@@ -3,6 +3,7 @@ Django settings for respa project.
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+import datetime
 import os
 import environ
 from django.utils.translation import ugettext_lazy as _
@@ -244,6 +245,7 @@ RESPA_MAILS_FROM_ADDRESS = ""
 RESPA_CATERINGS_ENABLED = False
 RESPA_COMMENTS_ENABLED = False
 RESPA_DOCX_TEMPLATE = os.path.join(BASE_DIR, 'reports', 'data', 'default.docx')
+RESPA_RESOURCE_DEFAULT_TIME_SLOT_DURATION = datetime.timedelta(minutes=30)
 
 
 # local_settings.py can be used to override environment-specific settings


### PR DESCRIPTION
If resource's minimum reservable time slot matches the configured default time slot duration (30 minutes), validate that the reservation conforms to that granularity. Otherwise enforce granularity of 5mins.