### PR TITLE
Update packages to make application work with Python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
 babel==2.6.0              # via delorean
 certifi==2018.11.29       # via requests, sentry-sdk
-cffi==1.11.5              # via cryptography
+cffi==1.12.2              # via cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via pip-tools
 coverage==4.5.2           # via -r requirements.in, pytest-cov
@@ -82,7 +82,7 @@ oauthlib==3.0.0           # via requests-oauthlib
 pillow==7.0.0             # via easy-thumbnails
 pip-tools==4.5.1          # via -r requirements.in
 pluggy==0.8.1             # via pytest
-psycopg2==2.7.6.1         # via -r requirements.in
+psycopg2==2.8.6           # via -r requirements.in
 py==1.7.0                 # via pytest
 pyasn1==0.4.8             # via python-jose, rsa
 pycodestyle==2.4.0        # via flake8


### PR DESCRIPTION
- cffi 1.11.5 > 1.12.2
- psycopg2 2.7.6.1 > 2.8.6