### PR TITLE
Define basicConfig for logging the output of management command

### DIFF
--- a/payments/management/commands/expire_too_old_unpaid_orders.py
+++ b/payments/management/commands/expire_too_old_unpaid_orders.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from django.core.management.base import BaseCommand
 from django.db.transaction import atomic
@@ -13,6 +14,12 @@ class Command(BaseCommand):
 
     @atomic
     def handle(self, *args, **options):
+        logging.basicConfig(
+            level = logging.INFO,
+            format = "%(asctime)s %(message)s",
+            datefmt = "%Y-%m-%d %H:%M:%S",
+            stream = sys.stdout
+        )
         logger.info('Expiring too old unpaid orders...')
         num_of_updated_orders = Order.objects.update_expired()
         logger.info('Done, {} order(s) got expired.'.format(num_of_updated_orders))


### PR DESCRIPTION
Currently management command doesn't output anything as the loggers default logging level is WARNING. This sets the default log level to be INFO in the management command. Also add timestamp to make it easier to debug issues from log files.