### PR TITLE
RespaAdmin: Render equipment layout in single/double column

### DIFF
--- a/resources/models/equipment.py
+++ b/resources/models/equipment.py
@@ -28,7 +28,7 @@ class Equipment(ModifiableModel, AutoIdentifiedModel):
     class Meta:
         verbose_name = pgettext_lazy('singular', 'equipment')
         verbose_name_plural = pgettext_lazy('plural', 'equipment')
-        ordering = ('category', 'name')
+        ordering = ('name', 'category')
 
     def __str__(self):
         return get_translated(self, 'name')

--- a/respa_admin/static_src/styles/form/section-equipment.scss
+++ b/respa_admin/static_src/styles/form/section-equipment.scss
@@ -2,13 +2,19 @@
 
   .technical {
     padding: 24px 0 32px;
+    width: 75%;
+
+    .usage-checkbox {
+      padding-top: 5px;
+    }
 
     .checkbox-row {
+      column-count: 2;
 
       .custom-checkbox {
-        max-width: 25%;
         min-width: 200px;
-                
+        margin-left: 10px;
+
         label {
           font-weight: bold;
         }
@@ -20,3 +26,9 @@
     margin-top: 24px;
   }
 }
+
+@media (max-width: 600px) {
+    #equipment .technical .checkbox-row {
+      column-count: 1;
+    }
+  }


### PR DESCRIPTION
* Render the equipments in a single column for mobile devices and two columns for others
* Order the equipments first by name instead of category

<img width="1365" alt="Screenshot 2022-03-17 at 13 03 54" src="https://user-images.githubusercontent.com/19978017/158795809-4b4048e6-3dce-4fe4-b2b3-1f8865c623b6.png">

