### PR TITLE
Allow empty value for max_period in resource (TAM-107)

### DIFF
--- a/respa_admin/forms.py
+++ b/respa_admin/forms.py
@@ -79,6 +79,10 @@ thirty_minute_increment_choices = (
     ('23:30:00', '23,5 h'),
 )
 
+thirty_minute_increment_choices_with_empty_start_value = (
+    (('', '---'),) + thirty_minute_increment_choices
+)
+
 
 class DaysForm(forms.ModelForm):
     opens = forms.TimeField(
@@ -242,7 +246,7 @@ class ResourceForm(forms.ModelForm):
                 choices=(thirty_minute_increment_choices)
             ),
             'max_period': forms.Select(
-                choices=(thirty_minute_increment_choices)
+                choices=(thirty_minute_increment_choices_with_empty_start_value)
             ),
             'slot_size': forms.Select(
                 choices=(thirty_minute_increment_choices)


### PR DESCRIPTION
Allow the maximum reservable period (max_period) for a resource
to be empty, so that they can be reserved for the whole slot
during the opening hours.
