### PR TITLE
Allow admins to copy resources (TAM-121)

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1400,6 +1400,9 @@ msgstr "Näkyvyys"
 msgid "Edit"
 msgstr "Muokkaa"
 
+msgid "Copy"
+msgstr "Kopioi"
+
 msgid "Unit management"
 msgstr "Toimipaikan hallinta"
 
@@ -1578,6 +1581,13 @@ msgstr "Muokkaa resurssia"
 
 msgid "Create new resource"
 msgstr "Luo uusi resurssi"
+
+#, python-brace-format
+msgid "{source_resource.name} copied successfully."
+msgstr "{source_resource.name} kopioitu onnistuneesti."
+
+msgid "Something went wrong! Please contact admin."
+msgstr "Jokin meni vikaan! Ota yhteyttä ylläpitäjään."
 
 msgid "Unit saved"
 msgstr "Toimipiste tallennettu"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1393,6 +1393,9 @@ msgstr "Synlighet"
 msgid "Edit"
 msgstr "Redigera"
 
+msgid "Copy"
+msgstr "Kopiera"
+
 msgid "Unit management"
 msgstr "Enhetshantering"
 
@@ -1571,6 +1574,13 @@ msgstr "Modifiera resurs"
 
 msgid "Create new resource"
 msgstr "Skapa ny resurs"
+
+#, python-brace-format
+msgid "{source_resource.name} copied successfully."
+msgstr "{source_resource.name} framgångsrikt kopierat."
+
+msgid "Something went wrong! Please contact admin."
+msgstr "Något gick fel! Kontakta admin."
 
 msgid "Unit saved"
 msgstr "Enheten sparad"

--- a/respa_admin/static_src/styles/page-resource.scss
+++ b/respa_admin/static_src/styles/page-resource.scss
@@ -9,3 +9,10 @@
   padding-right: 0;
   pointer-events: none;
 }
+
+ul.list-group .list-group-item .panel-body .col-5 {
+  align-items: center;
+  align-self: center;
+  justify-content: space-between;
+  flex-direction: row;
+}

--- a/respa_admin/templates/respa_admin/resources/_resource_list.html
+++ b/respa_admin/templates/respa_admin/resources/_resource_list.html
@@ -115,6 +115,10 @@
                                         <span class='glyphicon glyphicon-pencil icon-left' aria-hidden="true"></span>
                                         <a href="{% url 'respa_admin:edit-resource' resource_id=resource.id %}">{% trans 'Edit' %}</a>
                                     </h6>
+                                    <h6>
+                                        <span class='glyphicon glyphicon-duplicate icon-left' aria-hidden="true"></span>
+                                        <a href="{% url 'respa_admin:copy-resource' resource_id=resource.id %}">{% trans 'Copy' %}</a>
+                                    </h6>
                                 </div>
                             </div>
                         </div>

--- a/respa_admin/urls.py
+++ b/respa_admin/urls.py
@@ -4,8 +4,12 @@ from django.urls import include
 from . import views
 from .auth import admin_url as url
 from .views.resources import (
-    ManageUserPermissionsListView, ManageUserPermissionsSearchView, ManageUserPermissionsView, ResourceListView,
-    SaveResourceView
+    copy_resource,
+    ManageUserPermissionsListView,
+    ManageUserPermissionsSearchView,
+    ManageUserPermissionsView,
+    ResourceListView,
+    SaveResourceView,
 )
 from .views.units import UnitEditView, UnitListView
 
@@ -19,6 +23,7 @@ urlpatterns = [
     url(r'^resources/$', ResourceListView.as_view(), name='resources'),
     url(r'^resource/new/$', SaveResourceView.as_view(), name='new-resource'),
     url(r'^resource/edit/(?P<resource_id>\w+)/$', SaveResourceView.as_view(), name='edit-resource'),
+    url(r'^resource/copy/(?P<resource_id>\w+)/$', copy_resource, name='copy-resource'),
     url(r'^units/$', UnitListView.as_view(), name='units'),
     url(r'^units/edit/(?P<unit_id>[\w\d:]+)/$', UnitEditView.as_view(), name='edit-unit'),
     url(r'^i18n/$', include('django.conf.urls.i18n'), name='language'),

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -1,7 +1,10 @@
 from django.conf import settings
 from django.contrib import messages
+from django.db import transaction
 from django.db.models import FieldDoesNotExist, Q
-from django.http import Http404, HttpResponseRedirect
+from django.forms import model_to_dict
+from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404, redirect, render, reverse
 from django.template.response import TemplateResponse
 from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
@@ -466,6 +469,67 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
             return
 
         ResourceAccessibility.objects.filter(resource=self.object).exclude(pk__in=resource_accessibility_ids).delete()
+
+RESOURCE_RELATED_FIELDS = (
+    'images',
+    'opening_hours',
+    'periods',
+    'accessibility_summaries',
+)
+
+
+@transaction.atomic
+def copy_resource(request, resource_id):
+    source_resource = get_object_or_404(Resource.objects.prefetch_related(*RESOURCE_RELATED_FIELDS), pk=resource_id)
+    kwargs = model_to_dict(source_resource, exclude=['pk', 'name'])
+    resource_copy_name = _get_resource_copy_name(source_resource)
+    kwargs['name'] = resource_copy_name
+    kwargs['name_fi'] = resource_copy_name
+    kwargs['name_en'] = resource_copy_name
+    kwargs['name_sv'] = resource_copy_name
+    kwargs['public'] = False
+    form = ResourceForm(kwargs)
+
+    if form.is_valid():
+        copy_instance = form.save()
+        _copy_related_and_nested_objects(source_resource, copy_instance)
+        messages.success(request, _(f'{source_resource.name} copied successfully.'))
+        return redirect(reverse('respa_admin:index') + '?order_by=-created_at')
+    else:
+        messages.error(request, _('Something went wrong! Please contact admin.'))
+        return render(request, 'respa_admin/_base.html')
+
+
+def _copy_related_and_nested_objects(source, dest):
+    """
+    It copies the related obj and nested related obj that can be added/edited in
+    Respa admin. There might be other nested obj, but only consider the ones that
+    are modifiable via Respa Admin. E.g. A resource can have many Periods and the
+    period in turn can have many Days which is editable in Respa Admin.
+    """
+    for field in RESOURCE_RELATED_FIELDS:
+        related_obj = getattr(source, field).all()
+        for item in related_obj:
+            orig_obj_pk = item.pk
+            item.pk = None
+            item.resource = dest
+            item.save()
+
+            # Copy the nested obj used that can be edited/added in Respa admin.
+            if field == 'periods':
+                source_days = Day.objects.filter(period=orig_obj_pk)
+                for source_day in source_days:
+                    source_day.pk = None
+                    source_day.period = item
+                    source_day.save()
+
+
+def _get_resource_copy_name(resource):
+    resource_copy_name = f'{resource.name}_COPY_'
+    copied_resource_count = Resource.objects.filter(name__icontains=resource_copy_name).count()
+    next_copy_count = copied_resource_count + 1
+    resource_copy_name = f'{resource.name}_COPY_{next_copy_count}'
+    return resource_copy_name
 
 def get_formset_ids(formset_name, data):
     count = to_int(data.get('{}-TOTAL_FORMS'.format(formset_name)))


### PR DESCRIPTION
Allow admins to copy the resources. The copied resource should
have a different name (original name _COPY_count). and set as 
hidden so that it won't be visible in the varaamo until  changed
manually.

![resource_copy](https://user-images.githubusercontent.com/19978017/167580448-00eca6f6-1703-44be-b621-783973f6c8fc.gif)
