### PR TITLE
Fix the migration ordering in resources app

### DIFF
--- a/resources/migrations/0094_add_mid_strength_authentication_option.py
+++ b/resources/migrations/0094_add_mid_strength_authentication_option.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('resources', '0092_auto_20211026_1113'),
+        ('resources', '0093_add_accessibility_description_to_resource'),
     ]
 
     operations = [


### PR DESCRIPTION
The migration file order was wrong. Didn't realise it back then as the pull requests were in review for quite sometime and forgot the dependency. 