### PR TITLE
Send reservation created emails to unit admins (TAM-103)

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -527,10 +527,10 @@ msgid "Invalid value in filter %(filter)s"
 msgstr "Virheellinen arvo filtterissä %(filter)s"
 
 msgid "You need to login with strong authentication to reserve this resource."
-msgstr "Sinun täytyy kirjautua vahvalla tunnistautumistavalla varataksesi tämän resurssin"
+msgstr "Sinun tulee kirjautua sisään vahvalla tunnistautumismenetelmällä varataksesi tämän tilan/resurssin"
 
 msgid "You need to login with mid authentication to reserve this resource."
-msgstr "Sinun täytyy kirjautua keskivahvalla tunnistautumistavalla varataksesi tämän resurssin"
+msgstr "Sinun tulee kirjautua sisään keskivahvalla tunnistautumismenetelmällä varataksesi tämän tilan/resurssin"
 
 msgid "reservations"
 msgstr "varaukset"

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -538,11 +538,10 @@ class ReservationAuthenticationLevelPermission(permissions.BasePermission):
 
     def _can_reserve_resource_with_current_login(self, request, resource):
         resource_authentication = resource.authentication
-        user_authentication = get_user_auth_backend(request)
-
-        if resource_authentication == 'none':
+        if resource_authentication in ('none', ''):
             return True
 
+        user_authentication = get_user_auth_backend(request)
         if user_authentication in self.STRONG_AUTHENTICATION:
             return True
 

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -703,6 +703,7 @@ class ReservationViewSet(munigeo_api.GeoModelAPIView, viewsets.ModelViewSet, Res
                 new_state = Reservation.CONFIRMED
 
         instance.set_state(new_state, self.request.user)
+        instance.send_reservation_created_mail_to_officials()
 
     def perform_update(self, serializer):
         old_instance = self.get_object()

--- a/resources/migrations/0094_add_mid_strength_authentication_option.py
+++ b/resources/migrations/0094_add_mid_strength_authentication_option.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('resources', '0092_auto_20211026_1113'),
+        ('resources', '0093_add_accessibility_description_to_resource'),
     ]
 
     operations = [

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -6,6 +6,7 @@ import pytz
 from django.utils import timezone
 import django.contrib.postgres.fields as pgfields
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.gis.db import models
 from django.utils import translation
 from django.utils.timezone import now
@@ -252,7 +253,6 @@ class Reservation(ModifiableModel):
         # Notifications
         if new_state == Reservation.REQUESTED:
             self.send_reservation_requested_mail()
-            self.send_reservation_requested_mail_to_officials()
         elif new_state == Reservation.CONFIRMED:
             if self.need_manual_confirmation():
                 self.send_reservation_confirmed_mail()
@@ -411,6 +411,7 @@ class Reservation(ModifiableModel):
                 reserver_email_address = user.email
             context = {
                 'resource': self.resource.name,
+                'state': _(self.state),
                 'begin': localize_datetime(self.begin),
                 'end': localize_datetime(self.end),
                 'begin_dt': self.begin,
@@ -508,8 +509,16 @@ class Reservation(ModifiableModel):
     def send_reservation_requested_mail(self):
         self.send_reservation_mail(NotificationType.RESERVATION_REQUESTED)
 
-    def send_reservation_requested_mail_to_officials(self):
-        notify_users = self.resource.get_users_with_perm('can_approve_reservation')
+    def send_reservation_created_mail_to_officials(self):
+        # Send mail to unit admins and officials who can approve this reservation
+        officials_who_can_approve_reservation = self.resource.get_users_with_perm(
+            'can_approve_reservation')
+        unit_admins_ids = self.resource.unit.authorizations.admin_level().values_list(
+            'authorized', flat=True
+        )
+        unit_admins = get_user_model().objects.filter(id__in=unit_admins_ids)
+        notify_users = officials_who_can_approve_reservation.union(unit_admins)
+
         if len(notify_users) > 100:
             raise Exception("Refusing to notify more than 100 users (%s)" % self)
         for user in notify_users:

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -1279,6 +1279,56 @@ def test_reservation_mails_in_finnish(
         'Varauksesi on peruttu.'
     )
 
+@override_settings(RESPA_MAILS_ENABLED=True)
+@pytest.mark.django_db
+def test_unit_admins_are_notified_when_reservation_is_created_along_with_officials_and_reserver(
+        general_admin, user_api_client,
+        list_url, reservation_data_extra, user, reservation_created_notification):
+    resource = Resource.objects.get(id=reservation_data_extra['resource'])
+    assign_perm('unit:can_approve_reservation', general_admin, resource.unit)
+    unit_admin = get_user_model().objects.create(
+        username='Unit admin',
+        first_name='Ozzy',
+        last_name='Official',
+        email='unit_admin@test.com',
+        is_staff=True,
+        is_general_admin=True,
+    )
+    UnitAuthorization.objects.create(
+        subject=resource.unit,
+        level=UnitAuthorizationLevel.admin,
+        authorized=unit_admin,
+    )
+
+    response = user_api_client.post(list_url, data=reservation_data_extra, format='json')
+
+    assert response.status_code == 201
+    # One mail to unit admin and another to official who can dis/approve
+    # the reservation and one to reserver
+    assert len(mail.outbox) == 3
+    for sent_mail in mail.outbox:
+        if sent_mail.to == user.email:
+            check_received_mail_exists(
+                'Normal reservation created subject.',
+                user.email,
+                'Normal reservation created body.',
+                clear_outbox=False,
+            )
+        elif sent_mail.to == unit_admin.email:
+            check_received_mail_exists(
+                'Reservation requested',
+                unit_admin.email,
+                'A new preliminary reservation has been made',
+                clear_outbox=False,
+            )
+        else:
+            check_received_mail_exists(
+                'Reservation requested',
+                general_admin.email,
+                'A new preliminary reservation has been made',
+                clear_outbox=False,
+            )
+
 
 @override_settings(RESPA_MAILS_ENABLED=True)
 @pytest.mark.django_db

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -1061,14 +1061,6 @@ def test_order_by_accessibility_inaccessible_unit(list_url, api_client, resource
 
 
 @pytest.mark.django_db
-def test_resource_with_accessibility_data_no_include(api_client, resource_with_accessibility_data, detail_url):
-    """ Resource endpoint should not include accessibility data when not explicitly included """
-    response = api_client.get(detail_url)
-    assert response.status_code == 200
-    assert 'accessibility_summaries' not in response.data
-
-
-@pytest.mark.django_db
 def test_resource_with_accessibility_data(api_client, resource_with_accessibility_data, detail_url):
     """ Resource endpoint should include accessibility data when include-parameter is used """
     url = "{}?include=accessibility_summaries".format(detail_url)

--- a/respa_admin/tests/conftest.py
+++ b/respa_admin/tests/conftest.py
@@ -29,6 +29,11 @@ EMPTY_RESOURCE_FORM_DATA = {
     'periods-MIN_NUM_FORMS': ['0'],
     'periods-MAX_NUM_FORMS': ['1000'],
 
+    'accessibility_summaries-TOTAL_FORMS': ['0'],
+    'accessibility_summaries-INITIAL_FORMS': ['0'],
+    'accessibility_summaries-MIN_NUM_FORMS': ['0'],
+    'accessibility_summaries-MAX_NUM_FORMS': ['1000'],
+
     'unit': '',
     'type': '',
     'name': '',


### PR DESCRIPTION
* Fix the failing tests
* Send out emails to admins and officials who can approve the 
   reservations when the reservation is created.


NOTE: This PR contains the commit of fixing the migration ordering
that is already fixed by https://github.com/andersinno/respa/pull/60