### PR TITLE
Bypass resource  authentication permission check for certain users (TAM-126)

### DIFF
--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -509,7 +509,6 @@ class ReservationPermission(permissions.BasePermission):
         return obj.can_modify(request.user)
 
 
-
 class ReservationAuthenticationLevelPermission(permissions.BasePermission):
     """
     This class matches the authentication level on resource with the current
@@ -521,6 +520,9 @@ class ReservationAuthenticationLevelPermission(permissions.BasePermission):
       Strong          ->       strong, mid, weak, none
       Mid             ->       mid, weak, none
       Weak            ->       weak, none
+
+    Unit admins/managers and officials who can make reservation should be able to
+    bypass this permission.
     """
     message = ''
     # TODO: Needs discussing with client which login method belongs to which level.
@@ -541,6 +543,14 @@ class ReservationAuthenticationLevelPermission(permissions.BasePermission):
         user_authentication = get_user_auth_backend(request)
 
         if resource_authentication == 'none':
+            return True
+        # Regular users don't have "can_make_reservations" permission. This permission
+        # can be given to staffs via the Django admin
+        if (
+            resource.is_admin(request.user) or
+            resource.is_manager(request.user) or
+            resource._has_perm(request.user, 'can_make_reservations')
+        ):
             return True
 
         if user_authentication in self.STRONG_AUTHENTICATION:

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -2664,3 +2664,37 @@ def test_resource_authentication_and_user_login_authentication_permission(
     response = user_api_client.post(list_url, reservation_data)
     assert response.status_code == status_code
 
+@pytest.mark.django_db
+@pytest.mark.parametrize('perm_type', ['unit', 'resource_group'])
+@mock.patch('resources.api.reservation.get_user_auth_backend')
+def test_unit_admins_managers_and_official_can_bypass_resource_auth_permisson(
+    mocked_auth_backend,
+    perm_type,
+    reservation_data_extra,
+    unit_admin_user,
+    unit_manager_user,
+    staff_user,
+    api_client,
+    list_url,
+    resource_in_unit,
+    group,
+):
+    resource_in_unit.authentication = 'strong'
+    resource_in_unit.save()
+    mocked_auth_backend.return_value = 'weak'
+    staff_user.groups.add(group)
+
+    if perm_type == 'unit':
+        assign_perm('unit:can_make_reservations', group, resource_in_unit.unit)
+    elif perm_type == 'resource_group':
+        resource_group = resource_in_unit.groups.create(name='test group')
+        assign_perm('group:can_make_reservations', group, resource_group)
+
+    for user in (staff_user, unit_admin_user, unit_manager_user):
+        api_client.force_authenticate(user=user)
+        response = api_client.post(list_url, data=reservation_data_extra)
+        assert response.status_code == 201
+        reservation_id = response.json()["id"]
+        # Delete the reservation to free the time slot so it can be reserved by other
+        # users in this for loop.
+        Reservation.objects.get(id=reservation_id).delete()


### PR DESCRIPTION
* Unit admins/managers and users with permission to create resources should be able to
   bypass the resource authentication permission check. E.g. Unit admin logged in with 
   weak authentication should be able to reserve resource that requires strong authentication.



NOTE: This PR is based off of https://github.com/andersinno/respa/pull/66 since it needed the proper migrations that is already fixed in the other PR and also to avoid conflict.  (Decoupled the dependency but still keeping the text here so I know which branch needs to be merged first).