### PR TITLE
Revert "Respa_Admin: Add resource area to respa admin" (TAM-143)

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1524,9 +1524,6 @@ msgstr "*Pakolliset kentät"
 msgid "Name and description"
 msgstr "Nimi ja kuvaus"
 
-msgid "Area"
-msgstr "Pinta-ala (m2)"
-
 msgid "Contact person"
 msgstr "Yhteyshenkilö"
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1513,9 +1513,6 @@ msgstr "*Obligatoriska fält"
 msgid "Name and description"
 msgstr "Namn och beskrivning"
 
-msgid "Area"
-msgstr "Yta (m2)"
-
 msgid "Contact person"
 msgstr "Kontaktperson"
 

--- a/respa_admin/forms.py
+++ b/respa_admin/forms.py
@@ -230,7 +230,6 @@ class ResourceForm(forms.ModelForm):
         ]
 
         fields = [
-            'area',
             'unit',
             'type',
             'purposes',

--- a/respa_admin/static_src/styles/form/section-info.scss
+++ b/respa_admin/static_src/styles/form/section-info.scss
@@ -4,7 +4,6 @@
     margin-top: 36px;
   }
 
-  .area,
   .description,
   .external-calendar {
 

--- a/respa_admin/templates/respa_admin/resources/form/_general_info.html
+++ b/respa_admin/templates/respa_admin/resources/form/_general_info.html
@@ -24,10 +24,6 @@
         {% include "respa_admin/forms/_textarea_input.html" with field=form.description_en %}
         {% include "respa_admin/forms/_textarea_input.html" with field=form.description_sv %}
     </div>
-    <div class="area">
-        <h4>{%  trans "Area" %}</h4>
-        {% include "respa_admin/forms/_input.html" with field=form.area %}
-    </div>
     <div class="contact-person">
         <h4>{% trans "Contact person" %}</h4>
         <p>{% trans "Contact person information is only for internal use." %}</p>


### PR DESCRIPTION
Resource area is already present in respa admin. Therefore,
revert the commit that introduced the duplicate area.

This reverts commit b585c478a94f7190333aff46cde0d0957cf1b83e.
