### PR TITLE
Respa admin text change and search filter change (TAM-152, TAM-153)

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1456,7 +1456,7 @@ msgid "Staff"
 msgstr "Henkilökunta"
 
 msgid "Admin"
-msgstr "Admin"
+msgstr "Ylläpitäjä"
 
 msgid "Viewer"
 msgstr "Katsoja"

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -221,8 +221,12 @@ class ManageUserPermissionsSearchView(ExtraContextMixin, ListView):
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self):
-        if self.search_query and '@' in self.search_query:
-            qs = self.model.objects.filter(email__iexact=self.search_query)
+        if self.search_query and len(self.search_query) > 3:
+            qs = self.model.objects.filter(
+                Q(email__icontains=self.search_query)
+                | Q(first_name__icontains=self.search_query)
+                | Q(last_name__icontains=self.search_query)
+            )
             return qs
         elif self.search_query and ' ' in self.search_query:
             try:


### PR DESCRIPTION
* Add finnish translation for `Admin`
* Allow users to be searched if the query string is 
   contained in email/first_name/last_name of user model.

