### PR TITLE
Externally reservable resource (TAM-160)

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -179,6 +179,20 @@ class ResourceSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_api.
     max_price_per_hour = serializers.SerializerMethodField()
     min_price_per_hour = serializers.SerializerMethodField()
     accessibility_summaries = ResourceAccessibilitySerializer(many=True, read_only=True)
+    can_only_be_reserved_externally = serializers.SerializerMethodField()
+
+    def get_can_only_be_reserved_externally(self, obj):
+        today = datetime.datetime.today()
+        opening_hours_period_exists = obj.periods.exists()
+        resource_has_external_reservation_link = obj.external_reservation_url
+        resource_period_is_not_valid = not obj.periods.filter(end__gte=today).exists()
+        if (
+            not opening_hours_period_exists or
+            resource_has_external_reservation_link or
+            resource_period_is_not_valid
+        ):
+            return True
+        return False
 
     def get_max_price_per_hour(self, obj):
         """Backwards compatibility for 'max_price_per_hour' field that is now deprecated"""


### PR DESCRIPTION
Add a field to resource serializer to determine if the resource should be
reserved externally. i.e. outside varaamo e.g by calling.

Resource should be reserved externally if any of these is met:
 * It has external reservation link
 * It doesn't have any period
 * If it has periods but none of it is valid anymore

This info will be used by varaamo to show the correct reservation
status.