### PR TITLE
Change reservable_after to only include today (TAM-145)

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -266,7 +266,7 @@ class ResourceSerializer(ExtraDataMixin, TranslatedModelSerializer, munigeo_api.
         if user and obj.is_admin(user):
             return None
         else:
-            return obj.get_reservable_after()
+            return obj.get_reservable_after(exclude_extra_day=True)
 
     def to_representation(self, obj):
         # we must parse the time parameters before serializing

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -721,8 +721,8 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
     def get_reservable_min_days_in_advance(self):
         return self.reservable_min_days_in_advance or self.unit.reservable_min_days_in_advance
 
-    def get_reservable_after(self):
-        return create_datetime_days_from_now(self.get_reservable_min_days_in_advance())
+    def get_reservable_after(self, exclude_extra_day=False):
+        return create_datetime_days_from_now(self.get_reservable_min_days_in_advance(), exclude_extra_day=exclude_extra_day)
 
     def has_rent(self):
         return self.products.current().rents().exists()

--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -220,9 +220,11 @@ def get_object_or_none(cls, **kwargs):
         return None
 
 
-def create_datetime_days_from_now(days_from_now):
+def create_datetime_days_from_now(days_from_now, exclude_extra_day=False):
     if days_from_now is None:
         return None
+    if exclude_extra_day:
+        return timezone.now() + datetime.timedelta(days=days_from_now)
 
     dt = timezone.now() + datetime.timedelta(days=days_from_now + 1)
     dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)


### PR DESCRIPTION
Previously, when a value is set for minimum_days_before_reservation the resource would be available to reserve after the value of minimum_days_before_reservation + 1 days. i.e. If the value is 1 the resource is available for reservation after 2 days from now (It will be reservable day after tomorrow).

However, client want it so that it doesn't add one extra day. i.e. If today is Monday and the minimum_days_before_reservation is set to 1, that means the resource should be reservable tomorrow but not today.
