### PR TITLE
Fix Exchange sync event listener (TTV-27)

### DIFF
--- a/respa_exchange/ews/notifications.py
+++ b/respa_exchange/ews/notifications.py
@@ -138,7 +138,7 @@ class GetStreamingEventsRequest(EWSRequest):
     """
     version = 'Exchange2013'
 
-    def __init__(self, subscription_ids, timeout_minutes=30):
+    def __init__(self, subscription_ids, timeout_minutes=30, impersonation=None):
         """
         Initialize the request.
 
@@ -150,7 +150,7 @@ class GetStreamingEventsRequest(EWSRequest):
             M.SubscriptionIds(*[T.SubscriptionId(x) for x in subscription_ids]),
             M.ConnectionTimeout(str(timeout_minutes)),
         )
-        super(GetStreamingEventsRequest, self).__init__(root)
+        super(GetStreamingEventsRequest, self).__init__(root, impersonation)
 
     def process_response(self, resp):
         gserm = resp.find('*//m:GetStreamingEventsResponseMessage', namespaces=NAMESPACES)

--- a/respa_exchange/listener.py
+++ b/respa_exchange/listener.py
@@ -63,6 +63,7 @@ class EventAwaiterThread(threading.Thread):
                 event_req = GetStreamingEventsRequest(
                     subscription_ids=self.subscription_ids,
                     timeout_minutes=self.timeout_minutes,
+                    impersonation=self.exchange.username,
                 )
                 try:
                     # Make sure we don't overwhelm the server with requests.


### PR DESCRIPTION
The impersonation header is required in the SOAP request when getting the calendar events for a subscribed resource using OAuth2. Use the email address of the ExchangeConfiguration instance for the impersonation.

Refs TTV-27