### PR TITLE
Price list edit permissions in Respa admin

### DIFF
--- a/respa_admin/templates/respa_admin/price_lists/price_list_confirm_delete.html
+++ b/respa_admin/templates/respa_admin/price_lists/price_list_confirm_delete.html
@@ -30,9 +30,7 @@
             {% trans "Samalla poistetaan seuraavat hinnoitellut tuotteet (resursseja ei poisteta):" %}
         </p>
         <ul>
-            {% for pp in object.priced_products.all %}
-                <li>{{ pp.product }}</li>
-            {% endfor %}
+            <li>{{ object.priced_product.product }}</li>
         </ul>
         <hr>
         <a href="{% url 'respa_admin:price-list' %}" rel="noopener noreferrer">

--- a/respa_admin/views/prices.py
+++ b/respa_admin/views/prices.py
@@ -32,7 +32,7 @@ class PriceListView(ExtraContextMixin, ListView):
         return context
 
     def get_queryset(self):
-        qs = PriceList.objects.all()
+        qs = PriceList.objects.modifiable_by(self.request.user)
 
         if self.search_query:
             qs = qs.filter(name__icontains=self.search_query)
@@ -71,8 +71,15 @@ class PriceListCreateView(ExtraContextMixin, CreateView):
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
         resource_id = self.request.GET.get("resource_id")
+        form.fields["resource"].queryset = form.fields["resource"].queryset.modifiable_by(
+            self.request.user
+        )
         form.fields["resource"].initial = resource_id
         return form
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        return qs.modifiable_by(self.request.user)
 
     def post(self, request, *args, **kwargs):
         self.object = None
@@ -135,6 +142,17 @@ class PriceListEditView(ExtraContextMixin, UpdateView):
             )
         )
 
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        form.fields["resource"].queryset = form.fields["resource"].queryset.modifiable_by(
+            self.request.user
+        )
+        return form
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        return qs.modifiable_by(self.request.user)
+
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
         form_class = self.get_form_class()
@@ -182,11 +200,6 @@ class PriceListDeleteView(ExtraContextMixin, DeleteView):
     pk_url_kwarg = "price_list_id"
     success_url = reverse_lazy("respa_admin:price-list")
 
-    def get_object(self, *args, **kwargs):
-        """ Check that the user has permissions to the object before passing to the view. """
-        price_list = super().get_object(*args, **kwargs)
-        if True:
-            # TODO
-            return price_list
-        else:
-            raise PermissionDenied()
+    def get_queryset(self):
+        qs = super().get_queryset()
+        return qs.modifiable_by(self.request.user)

--- a/respa_pricing/models/price.py
+++ b/respa_pricing/models/price.py
@@ -12,6 +12,8 @@ from payments.utils import (
     convert_aftertax_to_pretax,
     convert_pretax_to_aftertax,
 )
+from resources.models import Resource
+
 from .utils import generate_id
 
 
@@ -72,11 +74,21 @@ class EventType(AutoIdentifiedModelMixin, models.Model):
         return self.name
 
 
+class PriceListQuerySet(models.QuerySet):
+    def modifiable_by(self, user):
+        modifiable_resources_by_user = Resource.objects.modifiable_by(user)
+        return self.filter(
+            priced_product__product__resources__pk__in=modifiable_resources_by_user
+        )
+
+
 class PriceList(models.Model):
     name = models.CharField(
         verbose_name=_("Name"),
         max_length=100,
     )
+
+    objects = PriceListQuerySet.as_manager()
 
     class Meta:
         verbose_name = _("Price list")


### PR DESCRIPTION
Respa admin: Add price list modification permission checks
    
    - User can only see, edit and delete price lists if they have
    edit permissions to the linked resource.
    
    - When editing/creating a price list, the user can only select
    and link it to a resources that they have permissions to.

Refs TTVA-24