### PR TITLE
Add tax percentage to UserGroup and EventType string representations (TTVA-47)

### DIFF
--- a/respa_admin/templates/respa_admin/price_lists/_event_type_item_form.html
+++ b/respa_admin/templates/respa_admin/price_lists/_event_type_item_form.html
@@ -2,7 +2,7 @@
 
 <div class="row">
     {{ form.id }}
-    <div class="col-sm-2">
+    <div class="col-sm-3">
         {% include "respa_admin/forms/_select.html" with field=form.event_type skip_label=True %}
     </div>
     <div class="col-sm-2">

--- a/respa_admin/templates/respa_admin/price_lists/_user_group_item_form.html
+++ b/respa_admin/templates/respa_admin/price_lists/_user_group_item_form.html
@@ -2,7 +2,7 @@
 
 <div class="row">
     {{ form.id }}
-    <div class="col-sm-2">
+    <div class="col-sm-3">
         {% include "respa_admin/forms/_select.html" with field=form.user_group skip_label=True %}
     </div>
     <div class="col-sm-2">

--- a/respa_admin/templates/respa_admin/price_lists/price_list_form.html
+++ b/respa_admin/templates/respa_admin/price_lists/price_list_form.html
@@ -55,7 +55,7 @@
         <h4>{% trans "Prices by user group" %}</h4>
         <div id="user-group-prices" class="user-group-prices">
           <div class="row header">
-            <div class="col-sm-2">{{ user_group_item_formset.forms.0.user_group.label }}</div>
+            <div class="col-sm-3">{{ user_group_item_formset.forms.0.user_group.label }}</div>
             <div class="col-sm-2">{{ user_group_item_formset.forms.0.price.label }}</div>
             <div class="col-sm-2">{{ user_group_item_formset.forms.0.price_period.label }}</div>
             <div class="col-sm-2">{{ user_group_item_formset.forms.0.price_type.label }}</div>
@@ -83,7 +83,7 @@
         <h4>{% trans "Prices by event type" %}</h4>
         <div id="event-type-prices" class="event-type-prices">
           <div class="row header">
-            <div class="col-sm-2">{{ event_type_item_formset.empty_form.event_type.label }}</div>
+            <div class="col-sm-3">{{ event_type_item_formset.empty_form.event_type.label }}</div>
             <div class="col-sm-2">{{ event_type_item_formset.empty_form.price.label }}</div>
             <div class="col-sm-2">{{ event_type_item_formset.empty_form.price_period.label }}</div>
             <div class="col-sm-2">{{ event_type_item_formset.empty_form.price_type.label }}</div>

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -615,10 +615,8 @@ def to_int(string):
 def check_cost_center_code(request):
     """View for checking whether the resource's unit has a cost center code"""
 
-    print("check_cost_center_code")
     has_cost_center_code = False
     resource_id = request.GET.get("resource_id", None)
-    print("resource id:", resource_id)
     if resource_id:
         resource = Resource.objects.filter(id=resource_id).first()
         if resource:

--- a/respa_pricing/models/price.py
+++ b/respa_pricing/models/price.py
@@ -66,7 +66,7 @@ class UserGroup(AutoIdentifiedModelMixin, models.Model):
         verbose_name_plural = _("User groups")
 
     def __str__(self):
-        return self.name
+        return f"{self.name} (ALV {self.tax_percentage}%)"
 
 
 class EventType(AutoIdentifiedModelMixin, models.Model):
@@ -85,7 +85,7 @@ class EventType(AutoIdentifiedModelMixin, models.Model):
         verbose_name_plural = _("Event types")
 
     def __str__(self):
-        return self.name
+        return f"{self.name} (ALV {self.tax_percentage}%)"
 
 
 class PriceListQuerySet(models.QuerySet):


### PR DESCRIPTION
Add tax percentage to UserGroup and EventType string representations so they can be seen for the list items in the price list form views according to the selected user group or event type.

Make the user group / event type column slightly wider in the price list form view in Respa admin to accomodate the change.

Refs TTVA-47