### PR TITLE
Ttva 61 improve test setup

### DIFF
--- a/.github/workflows/respa-ci.yml
+++ b/.github/workflows/respa-ci.yml
@@ -28,8 +28,6 @@ jobs:
     - name: Install python packages
       run: |
         pip install -r requirements.txt
-        pip install git+https://github.com/Tampere/django-tamusers.git@3b93b96cacb4a9cb07a8e932dd5c3a8aa465dfc4#egg=django-tamusers
-        rm -rf src/
 
     # Not sure why some of the strings are not translated during test. Thus,
     # explicitly compile messages.

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ coverage
 django-cors-headers
 django-image-cropping
 easy_thumbnails
--e git+https://github.com/Tampere/django-tamusers.git@d4f78bfb1cbff278d02b1bcccd330393f8e78d86#egg=django-tamusers
+git+https://github.com/Tampere/django-tamusers.git@d4f78bfb1cbff278d02b1bcccd330393f8e78d86#egg=django-tamusers
 django-allauth
 djangorestframework-jwt
 django-storages[google]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 --no-binary psycopg2
 
--e git+https://github.com/Tampere/django-tamusers.git@3b93b96cacb4a9cb07a8e932dd5c3a8aa465dfc4#egg=django-tamusers
+git+https://github.com/Tampere/django-tamusers.git@3b93b96cacb4a9cb07a8e932dd5c3a8aa465dfc4#egg=django-tamusers
 arrow==0.13.0             # via -r requirements.in
 asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.2.1       # via pytest


### PR DESCRIPTION
1. Removes the "-e" flag from the django-tamusers dependency in requirements, so that we do not get the redundant "src" directory breaking the unit tests.

2. Update CI pipeline config to remove the re-install & "src" removal workaround.