### PR TITLE
Fix reservation total price precision issue

### DIFF
--- a/respa_pricing/models/price.py
+++ b/respa_pricing/models/price.py
@@ -142,7 +142,7 @@ class PriceList(models.Model):
         price_source = tax_source = user_group_item
 
         pre_tax_price_by_user_group = user_group_item.get_pretax_price_for_time_range(
-            begin, end
+            begin, end, rounded=False
         )
         pre_tax_price = pre_tax_price_by_user_group
 
@@ -152,7 +152,7 @@ class PriceList(models.Model):
 
         if event_item and pre_tax_price_by_user_group != 0:
             pre_tax_price_by_event = event_item.get_pretax_price_for_time_range(
-                begin, end
+                begin, end, rounded=False
             )
             tax_source = (
                 user_group_item


### PR DESCRIPTION
`Pricelist.get_price_info`: Do not round the price between conversions to pretax and back to aftertax, to ensure the decimal precision is not lost. 

e.g. The total price for a four hour reservation with a price of 60.00€ per hour will now be returned as 320.00€, not 319.99€.

Refs TTVA-53