### PR TITLE
Cancel CeePos payment for cancelled/expired orders (TTVA-55)

### DIFF
--- a/payments/exceptions.py
+++ b/payments/exceptions.py
@@ -26,3 +26,7 @@ class UnknownReturnCodeError(RespaPaymentError):
 
 class PaymentCreationFailedError(RespaPaymentError):
     """When payment creation fails or is cancelled by the payment service"""
+
+
+class PaymentCancellationFailedError(RespaPaymentError):
+    """When the payment cancellation fails"""

--- a/payments/models.py
+++ b/payments/models.py
@@ -16,7 +16,10 @@ from rest_framework import serializers
 from resources.models import Reservation, Resource
 from resources.models.utils import generate_id
 
-from .exceptions import OrderStateTransitionError
+from .exceptions import (
+    OrderStateTransitionError,
+    PaymentCancellationFailedError,
+)
 from .utils import convert_aftertax_to_pretax, get_price_period_display, rounded
 
 # The best way for representing non existing archived_at would be using None for it,
@@ -203,6 +206,23 @@ class Order(models.Model):
             )
 
         self.state = new_state
+
+        if new_state in (Order.EXPIRED, Order.CANCELLED):
+            if self.reservation.state == Reservation.WAITING_FOR_PAYMENT:
+                # Cancel any open payments to make sure the order cannot
+                # be paid after it's been cancelled in Respa.
+                from .providers import get_payment_provider
+
+                payment_provider = get_payment_provider(request=None)
+                try:
+                    payment_provider.cancel_payment(self)
+                    self.create_log_entry(message="Payment cancelled")
+                except NotImplementedError:
+                    pass
+                except PaymentCancellationFailedError as error:
+                    self.create_log_entry(
+                        message=f"Failed to cancel payment: {error}"
+                    )
 
         if new_state == Order.CONFIRMED:
             self.reservation.set_state(Reservation.CONFIRMED, None)

--- a/payments/providers/base.py
+++ b/payments/providers/base.py
@@ -23,6 +23,13 @@ class PaymentProvider:
         Implement this in your subclass. Should return a URL to which the user
         is redirected to actually pay the order."""
 
+    def cancel_payment(self, order: Order) -> bool:
+        """Cancel an open payment.
+
+        Implement this in your subclass. Should return True if the cancellation
+        is succesful."""
+        raise NotImplementedError
+
     def handle_success_request(self) -> HttpResponse:
         """Handle incoming payment success request from the payment provider.
 

--- a/payments/providers/cpu_ceepos.py
+++ b/payments/providers/cpu_ceepos.py
@@ -12,6 +12,7 @@ from ..exceptions import (
     DuplicateOrderError,
     OrderStateTransitionError,
     PayloadValidationError,
+    PaymentCancellationFailedError,
     PaymentCreationFailedError,
     ServiceUnavailableError,
     UnknownReturnCodeError,
@@ -92,6 +93,32 @@ class CPUCeeposProvider(PaymentProvider):
             return self.handle_initiate_payment_response(r.json())
         except RequestException as e:
             raise ServiceUnavailableError("Payment service is unreachable") from e
+
+    def cancel_payment(self, order: Order) -> bool:
+        """
+        Sends a request for cancelling a payment that was previously created.
+
+        Returns True if the payment is succesfully cancelled.
+        """
+
+        payload = {
+            "ApiVersion": "3.0.0",
+            "Source": self.config.get(RESPA_PAYMENTS_CEEPOS_API_KEY),
+            "Id": str(order.order_number),
+            "Mode": 3,
+            "Action": "delete payment",
+        }
+        secret = self.config.get(RESPA_PAYMENTS_CEEPOS_API_SECRET)
+
+        self.payload_add_checksum(payload, secret)
+
+        try:
+            r = requests.post(self.url_payment_api, json=payload, timeout=60)
+            r.raise_for_status()
+            return self.handle_cancel_payment_response(r.json())
+        except RequestException as e:
+            raise ServiceUnavailableError("Payment service is unreachable") from e
+
 
     def payload_add_products(self, payload, order):
         """Attaches product data to the payload
@@ -239,6 +266,40 @@ class CPUCeeposProvider(PaymentProvider):
             raise ServiceUnavailableError("Payment service is unavailable")
         elif status_code == 99:
             raise PayloadValidationError("Payment payload data validation failed")
+        else:
+            raise UnknownReturnCodeError(
+                "Status code was not recognized: {}".format(status_code)
+            )
+
+    def handle_cancel_payment_response(self, response) -> bool:
+        """
+        Handles CeePos' response to the cancel payment request.
+        If the payment is succesfully cancelled, returns True.
+
+        Relevant response statuses:
+            0 = Payment cannot be cancelled
+            1 = Payment cancellation complete
+            3 = Payment already completed, cannot delete
+            4 = Payment already deleted
+            98 = System error
+            99 = Faulty action request
+        """
+
+        status_code = response["Status"]  # The status of the payment cancellation action.
+        if status_code == 0:
+            raise PaymentCancellationFailedError("Payment cannot be cancelled")
+        if status_code == 1:
+            if not self.validate_ceepos_response(response):
+                raise PayloadValidationError("Invalid response checksum")
+            return True
+        elif status_code == 3:
+            raise PaymentCancellationFailedError("Payment already completed, cannot delete")
+        elif status_code == 4:
+            raise PaymentCancellationFailedError("Payment already deleted")
+        elif status_code == 98:
+            raise ServiceUnavailableError("Payment service is unavailable")
+        elif status_code == 99:
+            raise PayloadValidationError("Payment cancellation payload data validation failed")
         else:
             raise UnknownReturnCodeError(
                 "Status code was not recognized: {}".format(status_code)

--- a/payments/tests/test_cpu_ceepos.py
+++ b/payments/tests/test_cpu_ceepos.py
@@ -13,6 +13,7 @@ from payments.providers.cpu_ceepos import (
     CPUCeeposProvider,
     DuplicateOrderError,
     PayloadValidationError,
+    PaymentCancellationFailedError,
     ServiceUnavailableError,
     UnknownReturnCodeError,
 )
@@ -194,6 +195,112 @@ def test_handle_initiate_payment_error_unknown_code(payment_provider):
     )
     with pytest.raises(UnknownReturnCodeError):
         payment_provider.handle_initiate_payment_response(response)
+
+
+def test_handle_cancel_payment_success(payment_provider):
+    """Test the response handler recognizes success and returns True"""
+    response = json.loads(
+        """{
+        "Id": "12345",
+        "Status": 1,
+        "Reference": "10456",
+        "Action": "delete payment",
+        "PaymentAddress": "https://www.example.com/checkout",
+        "Hash": "640f21ee6d90fad77b417399dd09560ae59fb4e9cb48e9d806b1d8232c0e41e5"
+    }"""
+    )
+    assert payment_provider.handle_cancel_payment_response(response)
+
+
+def test_handle_cancel_payment_error_already_paid(payment_provider):
+    """
+    Test the response handler raises PaymentCancellationFailedError as expected
+    when the payment has already been made.
+    """
+    response = json.loads(
+        """{
+        "Id": "12345",
+        "Status": 3,
+        "Reference": "10456",
+        "Action": "delete payment",
+        "PaymentAddress": "https://www.example.com/checkout",
+        "Hash": "640f21ee6d90fad77b417399dd09560ae59fb4e9cb48e9d806b1d8232c0e41e5"
+    }"""
+    )
+    with pytest.raises(PaymentCancellationFailedError):
+        assert payment_provider.handle_cancel_payment_response(response)
+
+
+def test_handle_cancel_payment_error_already_deleted(payment_provider):
+    """
+    Test the response handler raises PaymentCancellationFailedError as expected
+    when the payment has already been cancelled.
+    """
+    response = json.loads(
+        """{
+        "Id": "12345",
+        "Status": 4,
+        "Reference": "10456",
+        "Action": "delete payment",
+        "PaymentAddress": "https://www.example.com/checkout",
+        "Hash": "640f21ee6d90fad77b417399dd09560ae59fb4e9cb48e9d806b1d8232c0e41e5"
+    }"""
+    )
+    with pytest.raises(PaymentCancellationFailedError):
+        assert payment_provider.handle_cancel_payment_response(response)
+
+
+def test_handle_cancel_payment_error_invalid_request_payload(payment_provider):
+    """
+    Test the response handler raises PayloadValidationError as expected.
+    """
+    response = json.loads(
+        """{
+        "Id": "12345",
+        "Status": 99,
+        "Reference": "10456",
+        "Action": "delete payment",
+        "PaymentAddress": "https://www.example.com/checkout",
+        "Hash": "640f21ee6d90fad77b417399dd09560ae59fb4e9cb48e9d806b1d8232c0e41e5"
+    }"""
+    )
+    with pytest.raises(PayloadValidationError):
+        assert payment_provider.handle_cancel_payment_response(response)
+
+
+def test_handle_cancel_payment_error_invalid_response_checksum(payment_provider):
+    """
+    Test the response handler raises PayloadValidationError when the response
+    checksum is invalid.
+    """
+    response = json.loads(
+        """{
+        "Id": "12345",
+        "Status": 1,
+        "Reference": "10456",
+        "Action": "delete payment",
+        "PaymentAddress": "https://www.example.com/checkout",
+        "Hash": "invalid"
+    }"""
+    )
+    with pytest.raises(PayloadValidationError):
+        assert payment_provider.handle_cancel_payment_response(response)
+
+
+def test_handle_cancel_payment_error_unknown_code(payment_provider):
+    """Test the response handler raises UnknownReturnCodeError as expected"""
+    response = json.loads(
+        """{
+        "Id": "12345",
+        "Status": 123,
+        "Reference": "10456",
+        "Action": "delete payment",
+        "PaymentAddress": "https://www.example.com/checkout",
+        "Hash": "640f21ee6d90fad77b417399dd09560ae59fb4e9cb48e9d806b1d8232c0e41e5"
+    }"""
+    )
+    with pytest.raises(UnknownReturnCodeError):
+        payment_provider.handle_cancel_payment_response(response)
 
 
 def test_payload_add_products_success(payment_provider, order_with_products):


### PR DESCRIPTION
When an order's state is set to `EXPIRED` or `CANCELLED`, e.g. via the `expire_too_old_unpaid_orders` management command, and the order is waiting for payment in Ceepos, we need to cancel the payment in Ceepos. This ensures that orders cancelled/expired it Respa can not be paid in Ceepos.

Refs TTVA-55