### PR TITLE
Add fine-grained check of allowed reservation states

### DIFF
--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -170,28 +170,12 @@ class ReservationSerializer(
         return extra_fields
 
     def validate_state(self, value):
-        instance = self.instance
-        request_user = self.context["request"].user
+        if self.instance and not self.instance.is_new_state_allowed(
+            value, self.context["request"].user
+        ):
+            raise ValidationError(_("Illegal state change"))
 
-        # new reservations will get their value regardless of this value
-        if not instance:
-            return value
-
-        # state not changed
-        if instance.state == value:
-            return value
-
-        if instance.resource.can_approve_reservations(request_user):
-            allowed_states = (
-                Reservation.REQUESTED,
-                Reservation.CONFIRMED,
-                Reservation.DENIED,
-                Reservation.WAITING_FOR_PAYMENT,
-            )
-            if instance.state in allowed_states and value in allowed_states:
-                return value
-
-        raise ValidationError(_("Illegal state change"))
+        return value
 
     def validate(self, data):
         reservation = self.instance

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -6,7 +6,7 @@ import pytz
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.gis.db import models
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.utils import timezone, translation
 from django.utils.translation import ugettext_lazy as _
@@ -356,6 +356,30 @@ class Reservation(ModifiableModel):
         if self.is_own(user):
             return True
         return self.resource.can_view_reservation_access_code(user)
+
+    def is_new_state_allowed(self, new_state, user):
+        """Checks that new state is permitted for this user."""
+
+        # if same state, always OK
+        if new_state == self.state:
+            return True
+
+        if not self.resource.can_approve_reservations(user):
+            return False
+
+        allowed_states = [self.CANCELLED]
+
+        if self.state == self.REQUESTED:
+            allowed_states += [self.DENIED]
+            if self.get_order():
+                allowed_states += [self.WAITING_FOR_PAYMENT]
+            else:
+                allowed_states += [self.CONFIRMED]
+
+        elif self.need_manual_confirmation():
+            allowed_states += [self.REQUESTED]
+
+        return new_state in allowed_states
 
     def set_state(self, new_state, user):
         # Make sure it is a known state

--- a/resources/tests/test_reservation.py
+++ b/resources/tests/test_reservation.py
@@ -2,6 +2,8 @@ import arrow
 import datetime
 import pytest
 from datetime import timedelta
+
+from guardian.shortcuts import assign_perm
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
@@ -318,3 +320,121 @@ def test_state_change_from_requested_to_waiting_for_payment_sets_approval_time(
     assert requested_reservation.approved_at == parse_datetime(
         "2023-01-01T11:00:00+02:00"
     )
+
+
+class TestIsAllowedSameState:
+    def create_reservation(self, resource, user, state):
+        begin = timezone.now()
+        end = begin + datetime.timedelta(hours=2)
+        reservation = Reservation.objects.create(
+            resource=resource,
+            begin=begin,
+            end=end,
+            user=user,
+            state=state,
+        )
+
+        assign_perm("unit:can_approve_reservation", user, resource.unit)
+
+        return reservation
+
+    @pytest.mark.django_db
+    def test_is_allowed_same_state(self, resource_in_unit, user):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.REQUESTED
+        )
+        assert reservation.is_new_state_allowed(Reservation.REQUESTED, user)
+
+    @pytest.mark.django_db
+    def test_is_not_allowed_user_not_permitted(self, resource_in_unit, user, user2):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.REQUESTED
+        )
+        assert not reservation.is_new_state_allowed(Reservation.CANCELLED, user2)
+
+    @pytest.mark.django_db
+    def test_is_allowed_cancelled_from_requested(self, resource_in_unit, user):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.REQUESTED
+        )
+        assert reservation.is_new_state_allowed(Reservation.CANCELLED, user)
+
+    @pytest.mark.django_db
+    def test_is_allowed_denied_from_requested(self, resource_in_unit, user):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.REQUESTED
+        )
+        assert reservation.is_new_state_allowed(Reservation.DENIED, user)
+
+    @pytest.mark.django_db
+    def test_is_allowed_confirmed_from_requested_if_no_order(
+        self, resource_in_unit, user
+    ):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.REQUESTED
+        )
+        assert reservation.is_new_state_allowed(Reservation.CONFIRMED, user)
+
+    @pytest.mark.django_db
+    def test_is_not_allowed_confirmed_from_requested_if_order(
+        self, resource_in_unit, user
+    ):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.REQUESTED
+        )
+        OrderFactory(reservation=reservation)
+        assert not reservation.is_new_state_allowed(Reservation.CONFIRMED, user)
+
+    @pytest.mark.django_db
+    def test_is_not_allowed_waiting_for_payment_from_requested_if_no_order(
+        self, resource_in_unit, user
+    ):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.REQUESTED
+        )
+        assert not reservation.is_new_state_allowed(
+            Reservation.WAITING_FOR_PAYMENT, user
+        )
+
+    @pytest.mark.django_db
+    def test_is_allowed_waiting_for_payment_from_requested_if_order(
+        self, resource_in_unit, user
+    ):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.REQUESTED
+        )
+        OrderFactory(reservation=reservation)
+
+        assert reservation.is_new_state_allowed(Reservation.WAITING_FOR_PAYMENT, user)
+
+    @pytest.mark.django_db
+    def test_is_allowed_cancelled_from_created(self, resource_in_unit, user):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.CREATED
+        )
+        assert reservation.is_new_state_allowed(Reservation.CANCELLED, user)
+
+    @pytest.mark.django_db
+    def test_is_not_allowed_denied_from_created(self, resource_in_unit, user):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.CREATED
+        )
+        assert not reservation.is_new_state_allowed(Reservation.DENIED, user)
+
+    @pytest.mark.django_db
+    def test_is_not_allowed_confirmed_from_created(self, resource_in_unit, user):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.CREATED
+        )
+        assert not reservation.is_new_state_allowed(Reservation.CONFIRMED, user)
+
+    @pytest.mark.django_db
+    def test_is_not_allowed_waiting_for_payment_from_created(
+        self, resource_in_unit, user
+    ):
+        reservation = self.create_reservation(
+            resource_in_unit, user, Reservation.CREATED
+        )
+        assert not reservation.is_new_state_allowed(
+            Reservation.WAITING_FOR_PAYMENT, user
+        )

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -1476,6 +1476,10 @@ def test_reservation_mails(
         "has been denied.",
     )
 
+    # reset to REQUESTED
+
+    Reservation.objects.update(state=Reservation.REQUESTED)
+
     # test CONFIRMED
     reservation_data_extra["state"] = Reservation.CONFIRMED
     response = api_client.put(detail_url, data=reservation_data_extra, format="json")
@@ -1580,6 +1584,9 @@ def test_reservation_mails_in_finnish(
         reservation_data_extra["reserver_email_address"],
         "Varauksesi on hylätty.",
     )
+
+    # reset to REQUESTED
+    Reservation.objects.update(state=Reservation.REQUESTED)
 
     # test CONFIRMED
     reservation_data_extra["state"] = Reservation.CONFIRMED


### PR DESCRIPTION
A new method Reservation.is_new_state_allowed() checks that a) the user has permission to change the state for this instance and b) that the new state is permitted, depending on current state and other factors.

Refs TTVA-102