### PR TITLE
Do not expire paid reservations (TTVA-112)

### DIFF
--- a/payments/exceptions.py
+++ b/payments/exceptions.py
@@ -28,5 +28,9 @@ class PaymentCreationFailedError(RespaPaymentError):
     """When payment creation fails or is cancelled by the payment service"""
 
 
+class PaymentAlreadyCompletedError(RespaPaymentError):
+    """When the payment cancellation fails due to being already paid"""
+
+
 class PaymentCancellationFailedError(RespaPaymentError):
     """When the payment cancellation fails"""

--- a/payments/management/commands/expire_too_old_unpaid_orders.py
+++ b/payments/management/commands/expire_too_old_unpaid_orders.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'Sets too old orders from state "waiting" to state "expired".'
+    help = 'Sets state of old orders awaiting payment from "waiting" to "expired" or "confirmed".'
 
     @atomic
     def handle(self, *args, **options):
@@ -20,6 +20,7 @@ class Command(BaseCommand):
             datefmt = "%Y-%m-%d %H:%M:%S",
             stream = sys.stdout
         )
-        logger.info('Expiring too old unpaid orders...')
-        num_of_updated_orders = Order.objects.update_expired()
-        logger.info('Done, {} order(s) got expired.'.format(num_of_updated_orders))
+        logger.info('Handling too old unpaid orders...')
+        num_of_expired_orders, num_of_confirmed_orders = Order.objects.update_expired()
+        logger.info('Done, {} order(s) got expired.'.format(num_of_expired_orders))
+        logger.info('{} paid order(s) got confirmed.'.format(num_of_confirmed_orders))

--- a/payments/models.py
+++ b/payments/models.py
@@ -16,7 +16,11 @@ from rest_framework import serializers
 from resources.models import Reservation, Resource
 from resources.models.utils import generate_id
 
-from .exceptions import OrderStateTransitionError, PaymentCancellationFailedError
+from .exceptions import (
+    OrderStateTransitionError,
+    PaymentAlreadyCompletedError,
+    PaymentCancellationFailedError,
+)
 from .utils import convert_aftertax_to_pretax, get_price_period_display, rounded
 
 # The best way for representing non existing archived_at would be using None for it,
@@ -148,8 +152,11 @@ class OrderQuerySet(models.QuerySet):
            AND reservation didn’t need manual approval (Reservation.approved_at==null)
            AND order is older than settings.RESPA_PAYMENTS_PAYMENT_WAITING_TIME
 
+        If the Order has actually already been paid but for some reason the state
+        doesn't reflect that (should not happen), confirm the order instead.
+
         Returns:
-            number of orders expired
+            tuple of number of orders expired and number of orders confirmed
         """
 
         now = timezone.now()
@@ -183,12 +190,18 @@ class OrderQuerySet(models.QuerySet):
             .distinct()
         )
 
-        counter = 0
+        num_of_orders_expired = 0
+        num_of_order_confirmed = 0
 
-        for counter, order in enumerate(for_expiry, 1):
-            order.set_state(self.model.EXPIRED)
+        for order in for_expiry:
+            try:
+                order.set_state(self.model.EXPIRED)
+                num_of_orders_expired += 1
+            except PaymentAlreadyCompletedError:
+                order.set_state(self.model.CONFIRMED)
+                num_of_order_confirmed += 1
 
-        return counter
+        return (num_of_orders_expired, num_of_order_confirmed)
 
 
 class Order(models.Model):
@@ -206,7 +219,7 @@ class Order(models.Model):
         (CANCELLED, _("cancelled")),
     )
 
-    payment_link = models.URLField(verbose_name=_('Payment Link'), blank=True)
+    payment_link = models.URLField(verbose_name=_("Payment Link"), blank=True)
 
     state = models.CharField(
         max_length=32, verbose_name=_("state"), choices=STATE_CHOICES, default=WAITING
@@ -284,8 +297,6 @@ class Order(models.Model):
                 )
             )
 
-        self.state = new_state
-
         if new_state in (Order.EXPIRED, Order.CANCELLED):
             if self.reservation.state == Reservation.WAITING_FOR_PAYMENT:
                 # Cancel any open payments to make sure the order cannot
@@ -301,6 +312,11 @@ class Order(models.Model):
                     pass
                 except PaymentCancellationFailedError as error:
                     self.create_log_entry(message=f"Failed to cancel payment: {error}")
+                except PaymentAlreadyCompletedError as error:
+                    self.create_log_entry(message=f"Failed to cancel payment: {error}")
+                    raise error
+
+        self.state = new_state
 
         if new_state == Order.CONFIRMED:
             self.reservation.set_state(Reservation.CONFIRMED, None)
@@ -473,4 +489,4 @@ class NotificationOrderSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Order
-        fields = ('id', 'order_lines', 'price', 'created_at', 'payment_link')
+        fields = ("id", "order_lines", "price", "created_at", "payment_link")

--- a/payments/providers/cpu_ceepos.py
+++ b/payments/providers/cpu_ceepos.py
@@ -12,6 +12,7 @@ from ..exceptions import (
     DuplicateOrderError,
     OrderStateTransitionError,
     PayloadValidationError,
+    PaymentAlreadyCompletedError,
     PaymentCancellationFailedError,
     PaymentCreationFailedError,
     ServiceUnavailableError,
@@ -305,7 +306,7 @@ class CPUCeeposProvider(PaymentProvider):
                 raise PayloadValidationError("Invalid response checksum")
             return True
         elif status_code == 3:
-            raise PaymentCancellationFailedError("Payment already completed, cannot delete")
+            raise PaymentAlreadyCompletedError("Payment already completed, cannot delete")
         elif status_code == 4:
             raise PaymentCancellationFailedError("Payment already deleted")
         elif status_code == 98:

--- a/payments/tests/test_cpu_ceepos.py
+++ b/payments/tests/test_cpu_ceepos.py
@@ -13,6 +13,7 @@ from payments.providers.cpu_ceepos import (
     CPUCeeposProvider,
     DuplicateOrderError,
     PayloadValidationError,
+    PaymentAlreadyCompletedError,
     PaymentCancellationFailedError,
     ServiceUnavailableError,
     UnknownReturnCodeError,
@@ -218,7 +219,7 @@ def test_handle_cancel_payment_success(payment_provider):
 
 def test_handle_cancel_payment_error_already_paid(payment_provider):
     """
-    Test the response handler raises PaymentCancellationFailedError as expected
+    Test the response handler raises PaymentAlreadyCompletedError as expected
     when the payment has already been made.
     """
     response = json.loads(
@@ -231,7 +232,7 @@ def test_handle_cancel_payment_error_already_paid(payment_provider):
         "Hash": "640f21ee6d90fad77b417399dd09560ae59fb4e9cb48e9d806b1d8232c0e41e5"
     }"""
     )
-    with pytest.raises(PaymentCancellationFailedError):
+    with pytest.raises(PaymentAlreadyCompletedError):
         assert payment_provider.handle_cancel_payment_response(response)
 
 

--- a/payments/tests/test_order.py
+++ b/payments/tests/test_order.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 
 from resources.models import Reservation
 
-from ..exceptions import OrderStateTransitionError
+from ..exceptions import OrderStateTransitionError, PaymentAlreadyCompletedError
 from ..factories import OrderFactory
 from ..models import Order, OrderLogEntry
 
@@ -154,7 +154,47 @@ def test_update_expired(
 
     num_orders = 1 if expired else 0
 
-    assert Order.objects.update_expired() == num_orders
+    assert Order.objects.update_expired()[0] == num_orders
+
+
+def test_update_expired_confirms_paid_orders(resource_with_opening_hours, user):
+    """
+    Test that when trying to expire an order that is waiting for payment but
+    has actually already been paid, the state is set to CONFIRMED instead.
+    """
+
+    now = timezone.now()
+
+    reservation = Reservation.objects.create(
+        resource=resource_with_opening_hours,
+        begin=now,
+        end=now + timedelta(hours=2),
+        user=user,
+        state=Reservation.WAITING_FOR_PAYMENT,
+    )
+
+    order = OrderFactory(reservation=reservation, state=Order.WAITING)
+
+    OrderLogEntry.objects.update(
+        timestamp=now - timedelta(hours=2),
+    )
+
+    orig_set_state = Order.set_state
+
+    def mocked_set_state(self, new_state):
+        if new_state == Order.EXPIRED:
+            raise PaymentAlreadyCompletedError()
+        return orig_set_state(self, new_state)
+
+    with patch("payments.models.Order.set_state", new=mocked_set_state):
+        expired, confirmed = Order.objects.update_expired()
+
+        assert expired == 0
+        assert confirmed == 1
+
+    order.refresh_from_db()
+    assert order.state == Order.CONFIRMED
+    assert order.reservation.state == Reservation.CONFIRMED
 
 
 def test_get_price_correct(order_with_products):


### PR DESCRIPTION
When trying to expire an order that is waiting for payment but has actually already been paid in CeePos, do not expire the order but confirm it instead. This should not happen but there have been cases where Respa thinks the order has not been paid yet even though it has been. This can happen if e.g. CeePos does not send the notification of a successful payment and therefore the state is not updated in Respa. The root cause for such cases should still be investigated but this at least fixes the issue of paid orders being cancelled.

Refs TTVA-112