### PR TITLE
Fix CeePos notify request checksum validation (TTVA-113)

### DIFF
--- a/payments/providers/cpu_ceepos.py
+++ b/payments/providers/cpu_ceepos.py
@@ -33,6 +33,7 @@ REQUEST_CHECKSUM_PARAMS = (
     "Id",
     "Status",
     "Reference",
+    "Payments",
     "PaymentMethod",
     "PaymentSum",
     "Timestamp",
@@ -230,7 +231,17 @@ class CPUCeeposProvider(PaymentProvider):
         the message has been received intact and directly from CeePos.
         """
         checksum_received = data["Hash"]
-        checksum_calc_values = [data[x] for x in params if x in data]
+        checksum_calc_values = []
+
+        for key, value in data.items():
+            if key not in params:
+                continue
+            if isinstance(value, list):
+                for item in value:
+                    checksum_calc_values.extend(item.values())
+            else:
+                checksum_calc_values.append(value)
+
         secret = self.config.get(RESPA_PAYMENTS_CEEPOS_API_SECRET)
         correct_checksum = self.calculate_checksum(checksum_calc_values, secret)
 

--- a/payments/tests/test_cpu_ceepos.py
+++ b/payments/tests/test_cpu_ceepos.py
@@ -549,7 +549,8 @@ def test_handle_notify_request_success(
         "Id": "abc123",
         "Status": "1",
         "Reference": "123",
-        "Hash": "daac0c407cc08b5e679bd2aaa1b39cc3e3e70b6cf5de8b9063cbc66bb9952fd5",
+        "Payments": [{'PaymentMethod': '51', 'PaymentSum': '500', 'Timestamp': '202305311008'}],
+        "Hash": "f3afa700560555501d857df09835fb0aa300a315272c65030c044704d9475567",
     }
     order_with_products.set_state(order_state)
 


### PR DESCRIPTION
The request payload for Ceepos' notify requests is not as described in the API documentation. Therefore the checksum validation failed. Make adjustments to the checksum calculation so that we use the correct parameters.

This should fix the issue with order states not updated in Respa after succesful payments in cases the user is not redirected to the success URL from Ceepos and we need to depend on the notify requests.

Example of CeePos notify request payload on succesful payment:
```
{'Id': 'abc123',
 'Status': '1',
 'Reference': '123',
 'Payments': [{
   'PaymentMethod': '51',
   'PaymentSum': '500',
   'Timestamp': '202305311008'
 }],
 'Hash': 'fba76edaed977c87944457219f2513f92d9c72dd6fc51614dcd953ff44ddfdbf'}
```

The checksum is calculated from a string that consists of the values of the parameters in the message as well as the Ceepos API secret key and then compared to the `Hash` parameter value in the message.


Refs TTVA-113