### PR TITLE
ResourceSerializer: Determine price type based on price list (TTVA-106)

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -231,6 +231,8 @@ class ResourceSerializer(
     )
     reservable_after = serializers.SerializerMethodField()
 
+    price_type = serializers.SerializerMethodField()
+
     min_price = serializers.SerializerMethodField()
     max_price = serializers.SerializerMethodField()
 
@@ -301,6 +303,11 @@ class ResourceSerializer(
         if obj.price_list:
             return obj.price_list.include_other_event_type_option
         return False
+
+    def get_price_type(self, obj):
+        if obj.price_list and obj.price_list.price_type:
+            return obj.price_list.price_type
+        return obj.price_type
 
     def get_max_price(self, obj):
         """Return max_price if pricing available, otherwise return None.

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -20,6 +20,7 @@ from resources.models import (
     Unit,
     UnitGroup,
 )
+from respa_pricing.models.price import PRICE_MIXED
 from respa_pricing.tests.factories import (
     EventTypeFactory,
     EventTypePriceListItemFactory,
@@ -579,9 +580,11 @@ def test_price_fields_with_pricing_info(
     assert response.data["min_price"] == Decimal("5.05")
     assert response.data["max_price"] == Decimal("10.00")
     assert response.data["free_to_use"] is False
-    assert (
-        response.data["price_type"] == resource_in_unit_with_product.PRICE_TYPE_HOURLY
-    )
+
+    # The price list determines the price type. When there are
+    # 'Per period' type prices, the price type should be 'mixed'
+    # since we don't know whether they are hourly, per 30 mins etc.
+    assert response.data["price_type"] == PRICE_MIXED
 
     assert response.data["pricing_user_groups"] == [
         {

--- a/respa_pricing/models/price.py
+++ b/respa_pricing/models/price.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 from django.db import models
 from django.utils.duration import duration_string
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
@@ -31,6 +32,7 @@ DEFAULT_TAX_PERCENTAGE = Decimal("24.00")
 
 PRICE_PER_PERIOD = "per_period"
 PRICE_FIXED = "fixed"
+PRICE_MIXED = "mixed"
 PRICE_TYPE_CHOICES = (
     (PRICE_PER_PERIOD, _("per period")),
     (PRICE_FIXED, _("fixed")),
@@ -119,6 +121,22 @@ class PriceList(models.Model):
 
     def __str__(self):
         return self.name
+
+    @cached_property
+    def price_type(self):
+        price_types = (
+            self.usergroup_prices.union(self.event_prices.all())
+            .values_list("price_type", flat=True)
+            .distinct()
+        )
+
+        if not price_types:
+            return None
+
+        if len(price_types) > 1 or PRICE_PER_PERIOD in price_types:
+            return PRICE_MIXED
+
+        return PRICE_FIXED
 
     @classmethod
     def get_price_info(cls, product, user_group_id, event_type_id, begin, end):


### PR DESCRIPTION
If the resource has a price list and the price list has prices other than just fixed prices, return `mixed` as the price type so the client knows the price information needs to be displayed differently.

Refs TTVA-106