### PR TITLE
Respa admin: if price list template, show the "include other option" if

### DIFF
--- a/respa_admin/templates/respa_admin/price_lists/price_list_form.html
+++ b/respa_admin/templates/respa_admin/price_lists/price_list_form.html
@@ -93,16 +93,17 @@
                         {% include "respa_admin/price_lists/_event_type_item_form.html" with form=event_type_item_formset.empty_form %}
                     </div>
                 </div>
+                {% blocktrans asvar t_other_event_type %}Note! If there are event type specific prices, the reserver can also select "None of the above" as the event type. In this case, the price is determined based on the selected user group.{% endblocktrans %}
                 {% if not price_list_template %}
                     <button id="event-type-item-add-more" class="btn add-more" type="button">
                         <span class="glyphicon glyphicon-plus-sign icon-left" aria-hidden="true"></span>
                         {% trans "Add item" %}
                     </button>
                     {% if form.instance.include_other_event_type_option %}
-                        <label class="extra-event-type-option-label">
-                            {% blocktrans %}Note! If there are event type specific prices, the reserver can also select "None of the above" as the event type. In this case, the price is determined based on the selected user group.{% endblocktrans %}
-                        </label>
+                        <label class="extra-event-type-option-label">{{ t_other_event_type }}</label>
                     {% endif %}
+                {% elif price_list_template.include_other_event_type_option %}
+                    <label class="extra-event-type-option-label">{{ t_other_event_type }}</label>
                 {% endif %}
             </div>
             <!-- Function buttons -->


### PR DESCRIPTION
![Screenshot from 2023-06-13 15-02-40](https://github.com/andersinno/respa/assets/131681805/80fd8d51-f829-4a75-b3b7-627fee558f2e)

https://andersinno.atlassian.net/jira/software/c/projects/TTVA/boards/11?modal=detail&selectedIssue=TTVA-115

See also https://andersinno.atlassian.net/browse/TTVA-27

This will show the rule for new/existing price lists based on templates, where the template value is true.