### PR TITLE
Resources: ensure price list min or max price is not overriden if zero

### DIFF
--- a/resources/api/resource.py
+++ b/resources/api/resource.py
@@ -320,7 +320,12 @@ class ResourceSerializer(
         """
         if obj.free_to_use:
             return None
-        return getattr(obj, "max_price", None) or obj.default_max_price
+
+        max_price = getattr(obj, "max_price", None)
+
+        if max_price is None:
+            max_price = obj.default_max_price
+        return max_price
 
     def get_min_price(self, obj):
         """Return `max_price` if pricing available, otherwise return
@@ -333,7 +338,12 @@ class ResourceSerializer(
         """
         if obj.free_to_use:
             return None
-        return getattr(obj, "min_price", None) or obj.default_min_price
+
+        min_price = getattr(obj, "min_price", None)
+
+        if min_price is None:
+            min_price = obj.default_min_price
+        return min_price
 
     def get_max_price_per_hour(self, obj):
         """Backwards compatibility for 'max_price_per_hour' field that

--- a/resources/tests/test_resource_api.py
+++ b/resources/tests/test_resource_api.py
@@ -631,7 +631,7 @@ def test_price_fields_with_no_pricing_info(
 
 
 @pytest.mark.django_db
-def test_price_fields_with_no_default_pricing(
+def test_price_fields_with_default_pricing_and_no_pricing_info(
     api_client, priced_product, resource_in_unit_with_product, detail_url
 ):
     resource_in_unit_with_product.price_type = (
@@ -654,6 +654,46 @@ def test_price_fields_with_no_default_pricing(
 
     assert response.data["pricing_user_groups"] == []
     assert response.data["pricing_event_types"] == []
+
+
+@pytest.mark.django_db
+def test_price_fields_with_default_pricing_and_min_price_zero(
+    api_client, priced_product, resource_in_unit_with_product, detail_url
+):
+    """If the min price in price list is zero, the calculated min price should also
+    be zero even if default min price is not null."""
+
+    resource_in_unit_with_product.price_type = (
+        resource_in_unit_with_product.PRICE_TYPE_HOURLY
+    )
+    resource_in_unit_with_product.free_to_use = False
+    resource_in_unit_with_product.default_min_price = 10.00
+    resource_in_unit_with_product.default_max_price = 30.00
+    resource_in_unit_with_product.save()
+
+    event_type = EventTypeFactory(
+        name_fi="Juhlat",
+        name_en="Parties",
+    )
+
+    EventTypePriceListItemFactory(
+        price_list=priced_product.price_list, price="0.00", event_type=event_type
+    )
+
+    user_group = UserGroupFactory(
+        name_fi="Opeskilijat",
+        name_en="Students",
+    )
+
+    UserGroupPriceListItemFactory(
+        price_list=priced_product.price_list, price="10.00", user_group=user_group
+    )
+
+    response = api_client.get(detail_url)
+    assert response.status_code == 200
+
+    assert response.data["min_price"] == 0.00
+    assert response.data["max_price"] == 10.00
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
We should fall back to the default min/max prices only if they are not available i.e. None. For example if the minimum calculated price list value is zero, then the min price should be zero.

https://andersinno.atlassian.net/browse/TTVA-119?focusedCommentId=10291

Additional context

The `Resource` min/max prices in the API serializer are calculated with the method `Resource.objects.with_pricing()` which should calculate the minimum and maximum prices based on the individual items of the price list associated with each resource.  These are added as annotated fields `min_price` and `max_price` respectively.  If there are no associated prices, then these will be  `NULL`. 

If that is the case, then we should fall back to the values `default_min_price` and `default_max_price` which are `Resource` decimal fields that can be set manually in the Respa admin UI or Django admin. A typical use-case is when a resource is not reserved directly in Varaamo, but through a third party, but we still want to show the price range to the end user.

However if the **calculated** min/max price (i.e. based on price list values) is zero then the min/max price should also be zero, i.e. we should not fall back to the value of `default_min_price`  and `default_max_price`. This is because some price options can still be zero, e.g. for certain groups, and the price range should always reflect this.

