### PR TITLE
Resource: remove note about "responsible person" info in form

### DIFF
--- a/respa_admin/templates/respa_admin/resources/form/_general_info.html
+++ b/respa_admin/templates/respa_admin/resources/form/_general_info.html
@@ -26,7 +26,6 @@
     </div>
     <div class="contact-person">
         <h4>{% trans "Contact person" %}</h4>
-        <p>{% trans "Contact person information is only for internal use." %}</p>
         {% include "respa_admin/forms/_textarea_input.html" with field=form.responsible_contact_info_fi %}
         {% include "respa_admin/forms/_textarea_input.html" with field=form.responsible_contact_info_en %}
         {% include "respa_admin/forms/_textarea_input.html" with field=form.responsible_contact_info_sv %}


### PR DESCRIPTION
https://andersinno.atlassian.net/jira/software/c/projects/TTVA/boards/11?modal=detail&selectedIssue=TTVA-125

This change just removes the "for internal use" text in the Respa admin form. The text was in any case incorrect, as the field "responsible_contact_info" is already public.

See also https://andersinno.atlassian.net/jira/software/c/projects/TTVA/boards/11?modal=detail&selectedIssue=TTVA-133