### PR TITLE
Ttva 33 calendar copy changes

### DIFF
--- a/respa_admin/forms.py
+++ b/respa_admin/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.core.exceptions import ValidationError
-from django.forms import inlineformset_factory
+from django.forms import inlineformset_factory, modelformset_factory
 from django.forms.formsets import DELETION_FIELD_NAME
 from django.utils.translation import ugettext_lazy as _
 from guardian.core import ObjectPermissionChecker
@@ -419,6 +419,39 @@ def get_resource_image_formset(request=None, extra=1, instance=None):
         return resource_image_formset(
             data=request.POST, files=request.FILES, instance=instance
         )
+
+
+def get_period_template_formset():
+    """Creates a read-only formset for rendering period templates.
+
+    The templates can be copied and amended with JS on the frontend and
+    added to the resource form.
+
+    As this formset is never validated or processed, we don't need to
+    worry about passing the resource instance.
+    """
+    forms = modelformset_factory(
+        Period,
+        form=PeriodForm,
+        extra=0,
+    )(
+        queryset=Period.objects.filter(is_template=True),
+        prefix="periods",
+    )
+
+    # add "days" formset to each form
+    for form in forms:
+        days_formset = inlineformset_factory(
+            Period, Day, form=DaysForm, extra=0, validate_max=True
+        )
+
+        form.days = days_formset(
+            instance=form.instance,
+            data=None,
+            prefix=f"days-{form.prefix}",
+        )
+
+    return forms
 
 
 def get_resource_accessibility_formset(request=None, extra=1, instance=None):

--- a/respa_admin/static_src/js/periods.js
+++ b/respa_admin/static_src/js/periods.js
@@ -4,11 +4,24 @@ let emptyDayItem = null;
 export function initializePeriods() {
   enablePeriodEventHandlers();
   enableAddNewPeriod();
+  enableTemplateCopyButton();
   setPeriodAndDayItems();
   initialSortPeriodDays();
   setPeriodTemplateOnFocus();
+  selectPeriodTemplates();
 }
 
+function selectPeriodTemplates() {
+  const $copyButton = $('#copy-button');
+  $('[name=period_templates]').on('click', function() {
+    if ($('[name=period_templates]:checked').length > 0) {
+      $copyButton.show();
+    } else {
+      $copyButton.hide();
+    }
+  });
+
+}
 function setPeriodTemplateOnFocus() {
   // Don't hide the period template options if focus is inside the drowndown
   $('.period-template-item input').on('click', function (e){
@@ -37,6 +50,25 @@ function initialSortPeriodDays() {
   for (let i = 0; i < periods.length; i++) {
     sortPeriodDays($(periods[i]));
   }
+}
+
+function enableTemplateCopyButton() {
+  // copy selected templates in the dropdown from the specified <template> contents
+  const $copyButton = $("#copy-button");
+
+  $copyButton.on("click", function() {
+    const $selectedTemplates = $('[name=period_templates]:checked');
+
+    for (let i=0; i < $selectedTemplates.length; i++) {
+      const option = $selectedTemplates[i];
+      const template =  $($("#period-template-" + option.value).html());
+      const newItem = copyTimePeriod(template);
+      newItem.find('[data-toggle="collapse"]').click();
+
+      option.checked = false;
+    }
+    $copyButton.hide();
+  });
 }
 
 function enablePeriodEventHandlers() {
@@ -85,8 +117,12 @@ function setPeriodAndDayItems() {
   emptyDayItem.removeClass('original-day');  // added days are not original. used for sorting formset indices.
   emptyPeriodItem = $($servedPeriodItem).clone();
 
-  $servedDayItem.remove();
-  $servedPeriodItem.remove();
+  if ($servedDayItem) {
+    $servedDayItem.remove();
+  }
+  if ($servedPeriodItem) {
+    $servedPeriodItem.remove();
+  }
 
   //Iterate the existing days in all periods and remove the last one
   //which has been added from the backend.
@@ -134,6 +170,7 @@ function updatePeriodButtonsIds(periodItem, idNum) {
 * */
 function updatePeriodChildren(periodItem, idNum) {
   periodItem.attr('id', `accordion-item-${idNum}`);
+  periodItem.find('.delete-time').attr('id', `remove-button-${idNum}`);
   periodItem.find('.dropdown-time').attr('id', `accordion${idNum}`);
   periodItem.find('.date-input').attr('id', `date-inputs-${idNum}`);
   periodItem.find('.panel-heading').attr({id: `heading${idNum}`});
@@ -145,9 +182,13 @@ function updatePeriodChildren(periodItem, idNum) {
   });
 
   periodItem.find('.panel-collapse').attr({
-    "aria-labelledby": `heading${idNum}`,
+    'aria-labelledby': `heading${idNum}`,
     id: `collapse${idNum}`
   });
+
+  periodItem.find('[data-toggle="collapse"]').attr(
+    'data-parent', `#accordion${idNum}`
+  );
 }
 
 /*
@@ -433,18 +474,18 @@ function removePeriodExtraDays(periodItem) {
 * */
 function addNewPeriod() {
   // Get the list or periods.
-  let $periodList = $('#current-periods-list');
-  let emptyPeriodItem = getEmptyPeriodItem();
-
+  const $periodList = $('#current-periods-list');
+  const emptyPeriodItem = getEmptyPeriodItem();
+  let newItem;
   if (emptyPeriodItem) {
-    let newItem = emptyPeriodItem.clone();
+    newItem = emptyPeriodItem.clone();
     $periodList.append(newItem);
-
     updatePeriodsTotalForms();
     removePeriodExtraDays(newItem);
     updatePeriodInputIds();
     attachPeriodEventHandlers(newItem);
   }
+  return newItem;
 }
 
 /*
@@ -523,6 +564,7 @@ function copyTimePeriod(periodItem) {
 
   //Reset initial forms in case there are some days present in the previous period.
   newItem.find('#days-management-form').find('[id$="-INITIAL_FORMS"]').val('0');
+  return newItem;
 }
 
 /*

--- a/respa_admin/templates/respa_admin/common/_period_day.html
+++ b/respa_admin/templates/respa_admin/common/_period_day.html
@@ -1,19 +1,14 @@
 {% load i18n %}
-
 {% with forloop.counter0 as dayId %}
-    <div class="weekday-row input-row original-day" id="period-day-{{ id }}-{{ dayId }}">
-
+    <div class="weekday-row input-row original-day"
+         id="period-day-{{ id }}-{{ dayId }}">
         <div id="day-db-ids" class="day-db-ids">
             {{ day.period }}
             {{ day.id }}
         </div>
-
         <div class="form-group">
-            <span class="select-dropdown btn btn-primary period-weekday">
-                {{ day.weekday }}
-            </span>
+            <span class="select-dropdown btn btn-primary period-weekday">{{ day.weekday }}</span>
         </div>
-
         <div class="form-group">
             <div class="time-input-row range-input">
                 {{ day.opens }}
@@ -21,11 +16,7 @@
                 {{ day.closes }}
             </div>
         </div>
-
-        <div class="form-group">
-            {{ day.closed }}
-        </div>
-
+        <div class="form-group">{{ day.closed }}</div>
         <div class="form-group">
             <button class="btn copy-next" type="button" id="copy-next-{{ id }}">
                 <span class="glyphicon glyphicon-duplicate icon-left" aria-hidden="true"></span>

--- a/respa_admin/templates/respa_admin/common/_periods_accordion.html
+++ b/respa_admin/templates/respa_admin/common/_periods_accordion.html
@@ -1,28 +1,36 @@
 {% load i18n %}
-
-<div class="accordion-item" id="accordion-item-{{id}}">
+<div class="accordion-item" id="accordion-item-{{ id }}">
     {{ period.id }}
     {% if period.resource.value %}
-        {{ period.resource }}
-    {% else %}
-        {{ period.unit }}
+        Resource {{ period.resource }}
+    {% elif period.unit %}
+        Unit {{ period.unit }}
     {% endif %}
-    <div class="dropdown-time panel-group input-row" id="accordion{{id}}" role="tablist" aria-multiselectable="true">
+    <div class="dropdown-time panel-group input-row"
+         id="accordion{{ id }}"
+         role="tablist"
+         aria-multiselectable="true">
         <div class="panel-heading">
             <div class="left-group">
                 {% trans 'New period' as translated_unnamed_title %}
-                {% if period.instance.template_src %}
-                    <span class="glyphicon glyphicon-bookmark icon-left"></span>
-                {% endif %}
+                {% if period.instance.template_src %}<span class="glyphicon glyphicon-bookmark icon-left"></span>{% endif %}
                 <span class="panel-heading-tag">{{ period.name.value|default_if_none:translated_unnamed_title }}</span>
                 <span class="panel-heading-period">{{ period.start.value|date:"j.n.Y" }} - {{ period.end.value|date:"j.n.Y" }}</span>
             </div>
             <div class="right-group">
-                <button class="btn copy-time-btn" type="button" id="copy-time-period-{{ id }}">
+                <button class="btn copy-time-btn"
+                        type="button"
+                        id="copy-time-period-{{ id }}">
                     <span class="glyphicon glyphicon-duplicate icon-left" aria-hidden="true"></span>
                     {% trans "Copy time period" %}
                 </button>
-                <a class="btn" role="button" data-toggle="collapse" data-parent="#accordion{{id}}" href="#collapse{{id}}" aria-expanded="true" aria-controls="#collapse{{id}}">
+                <a class="btn"
+                   role="button"
+                   data-toggle="collapse"
+                   data-parent="#accordion{{ id }}"
+                   href="#collapse{{ id }}"
+                   aria-expanded="true"
+                   aria-controls="#collapse{{ id }}">
                     <span class="glyphicon glyphicon-edit icon-left"></span>
                     {% trans "Edit time period" %}
                     <span class="glyphicon glyphicon-chevron-down icon-right"></span>
@@ -30,8 +38,10 @@
             </div>
         </div>
     </div>
-
-    <div class="panel-collapse collapse" role="tabpanel" id="collapse{{id}}" aria-labelledby="heading{{id}}">
+    <div class="panel-collapse collapse"
+         role="tabpanel"
+         id="collapse{{ id }}"
+         aria-labelledby="heading{{ id }}">
         <div class="container-fluid hours-wrapper">
             <div class="hours-table-header" id="period-list">
                 <div class="input-row period-input" id="period-input-{{ id }}">
@@ -49,21 +59,16 @@
                     </div>
                 </div>
             </div>
-
-            <div class="hidden" id="days-management-form">
-                {{ period.days.management_form }}
-            </div>
-
+            <div class="hidden" id="days-management-form">{{ period.days.management_form }}</div>
             <div id="period-days-list">
                 {% for day in period.days %}
                     {% include "respa_admin/common/_period_day.html" with day=day %}
                 {% endfor %}
             </div>
-
             <div class="footer-buttons">
-                <button class="btn pull-left delete-time btn-danger" type="button" id="remove-button-{{ id }}">
-                    {% trans "Remove time period" %}
-                </button>
+                <button class="btn pull-left delete-time btn-danger"
+                        type="button"
+                        id="remove-button-{{ id }}">{% trans "Remove time period" %}</button>
             </div>
         </div>
     </div>

--- a/respa_admin/templates/respa_admin/resources/form/_period_template.html
+++ b/respa_admin/templates/respa_admin/resources/form/_period_template.html
@@ -1,28 +1,32 @@
 {% load i18n %}
-
+{% for form in period_template_formset %}
+    <template id="period-template-{{ form.instance.pk }}">
+        {% include "respa_admin/common/_periods_accordion.html" with id=form.instance.pk period=form %}
+    </template>
+{% endfor %}
 <div class="period-templates">
-    <button class="btn btn-default dropdown-toggle select-dropdown" type="button"
-          id="periodTemplates" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+    <button class="btn btn-default dropdown-toggle select-dropdown"
+            type="button"
+            id="periodTemplates"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="true">
         {% trans "Select from templates" %}
-        <div class="glyphicon glyphicon-chevron-down" aria-hidden="true"/>
+        <div class="glyphicon glyphicon-chevron-down" aria-hidden="true" />
     </button>
-
     <ul class="dropdown-menu" aria-labelledby="periodTemplates">
         <div class="usage-checkbox checkbox-row" id="id_period_templates">
             {% for pk, choice in form.period_templates.field.choices %}
                 <div class="custom-checkbox period-template-item">
                     <li>
-                        <input
-                          id="id_period_templates_{{ forloop.counter0 }}"
-                          name="period_templates"
-                          type="checkbox"
-                          class="checkbox-custom"
-                          value="{{pk}}"
-                          {% if pk in used_period_templates %}checked{% endif %}
-                        />
-                        <label for="id_period_templates_{{ forloop.counter0 }}" class="checkbox-custom-label input-label">
-                            {{ choice }}
-                        </label>
+                        <input id="id_period_templates_{{ forloop.counter0 }}"
+                               name="period_templates"
+                               type="checkbox"
+                               class="checkbox-custom"
+                               value="{{ pk }}"
+                               {% if pk in used_period_templates %}checked{% endif %} />
+                        <label for="id_period_templates_{{ forloop.counter0 }}"
+                               class="checkbox-custom-label input-label">{{ choice }}</label>
                     </li>
                 </div>
             {% endfor %}

--- a/respa_admin/templates/respa_admin/resources/form/_periods.html
+++ b/respa_admin/templates/respa_admin/resources/form/_periods.html
@@ -1,25 +1,20 @@
 {% load i18n %}
-
 <div id="opening-hours">
     <div class="form-section-header">
         <h2>{% trans "Opening hours" %}</h2>
     </div>
-
     <div class="input-row dropdown-row">
         <button class="resources-button" type="button" id="add-new-hour">{% trans "Add new time period" %}</button>
-        <div class="select-dropdown btn btn-primary">
-            <select>
-                <option>{% trans "Add general time period" %}</option>
-            </select>
-            <span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>
-        </div>
         {% include "respa_admin/resources/form/_period_template.html" %}
+        <button class="resources-button"
+                type="button"
+                id="copy-button"
+                style="display: none">{% trans "Copy" %}</button>
     </div>
-
     <div class="present-hours-list" id="current-periods-list">
         {% for period in formset %}
             {% with forloop.counter0 as id %}
-            {% include "respa_admin/common/_periods_accordion.html" with period=period id=id %}
+                {% include "respa_admin/common/_periods_accordion.html" with period=period id=id %}
             {% endwith %}
         {% endfor %}
     </div>

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -25,6 +25,7 @@ from resources.models import (
 from respa_admin import accessibility_api, forms
 from respa_admin.forms import (
     ResourceForm,
+    get_period_template_formset,
     get_resource_accessibility_formset,
     get_resource_image_formset,
     get_unit_authorization_formset,
@@ -311,6 +312,7 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
         resource_accessibility_formset = get_resource_accessibility_formset(
             self.request, instance=self.object
         )
+        period_template_formset = get_period_template_formset()
 
         trans_fields = forms.get_translated_field_count(resource_image_formset)
 
@@ -322,6 +324,7 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
                 form=form,
                 resource_accessibility_formset=resource_accessibility_formset,
                 resource_image_formset=resource_image_formset,
+                period_template_formset=period_template_formset,
                 trans_fields=trans_fields,
                 page_headline=page_headline,
             )
@@ -382,6 +385,8 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
             request=request, instance=self.object
         )
 
+        period_template_formset = get_period_template_formset()
+
         if self._validate_forms(
             form,
             period_formset_with_days,
@@ -398,6 +403,7 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
             return self.forms_invalid(
                 form,
                 period_formset_with_days,
+                period_template_formset,
                 resource_image_formset,
                 resource_accessibility_formset,
             )
@@ -432,6 +438,7 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
         self,
         form,
         period_formset_with_days,
+        period_template_formset,
         resource_image_formset,
         resource_accessibility_formset,
     ):
@@ -455,6 +462,7 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
             self.get_context_data(
                 form=form,
                 period_formset_with_days=period_formset_with_days,
+                period_template_formset=period_template_formset,
                 resource_image_formset=resource_image_formset,
                 resource_accessibility_formset=resource_accessibility_formset,
                 trans_fields=trans_fields,


### PR DESCRIPTION
![Screenshot from 2023-07-05 09-48-05](https://github.com/andersinno/respa/assets/131681805/86f768ca-3a3a-4893-975c-bb6bb5c0ccf0)

https://andersinno.atlassian.net/jira/software/c/projects/TTVA/boards/11?modal=detail&selectedIssue=TTVA-33

This change uses a read-only Django formset to render the period templates inside `<template>` tags. When the copy button is clicked, the template contents are copied into the period form list. This lets us re-use the existing copy functionality for periods.