### PR TITLE
Respa admin: added missing translation

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1125,6 +1125,9 @@ msgstr "Oletusminimihinta"
 msgid "Default max price"
 msgstr "Oletusmaksimihinta"
 
+msgid "Price type for default prices"
+msgstr "Hintatyyppi oletushinnoille"
+
 msgid "Price displayed if no price list info attached to this resource."
 msgstr "Hinta näytetään mikäli resurssilla ei ole hinnastoa."
 

--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -398,7 +398,7 @@ class Resource(ModifiableModel, AutoIdentifiedModel):
     )
 
     price_type = models.CharField(
-        verbose_name=_("Price type for default min/max prices"),
+        verbose_name=_("Price type for default prices"),
         max_length=32,
         choices=PRICE_TYPE_CHOICES,
         default=PRICE_TYPE_HOURLY,


### PR DESCRIPTION
Finnish translation added for default price type field

[Refs TTVA-135](https://andersinno.atlassian.net/jira/software/c/projects/TTVA/boards/11?modal=detail&selectedIssue=TTVA-135)