### PR TITLE
Ttva 136 submit new period no data

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1435,8 +1435,8 @@ msgstr "Aikaväli"
 msgid "Remove time period"
 msgstr "Poista ajanjakso"
 
-msgid "Tarkista seuraavat virheet"
-msgstr "Check the following errors"
+msgid "Check the following errors"
+msgstr "Tarkista seuraavat virheet"
 
 msgid "Choose image"
 msgstr "Valitse kuva"

--- a/respa_admin/templates/respa_admin/forms/_form_errors.html
+++ b/respa_admin/templates/respa_admin/forms/_form_errors.html
@@ -1,32 +1,9 @@
 {% load i18n %}
-
-{% if form.errors or resource_image_formset.errors or period_formset_with_days.errors or resource_accessibility_formset.errors %}
+{% if errors %}
     <div class="alert alert-danger">
-        <strong>{% trans "Tarkista seuraavat virheet" %}:</strong>
+        <strong>{% trans "Check the following errors" %}:</strong>
         <ul>
-            {% for error in form.errors %}
-                <li>
-                    {{ error }}
-                </li>
-            {% endfor %}
-
-            {% for error in resource_image_formset.errors %}
-                <li>
-                    {{ error }}
-                </li>
-            {% endfor %}
-
-            {% for error in period_formset_with_days.errors %}
-                <li>
-                    {{ error }}
-                </li>
-            {% endfor %}
-
-            {% for error in resource_accessibility_formset.errors %}
-                <li>
-                    {{ error }}
-                </li>
-            {% endfor %}
+            {{ errors|unordered_list }}
         </ul>
     </div>
 {% endif %}

--- a/respa_admin/templates/respa_admin/resources/create_resource.html
+++ b/respa_admin/templates/respa_admin/resources/create_resource.html
@@ -1,24 +1,16 @@
 {% extends "respa_admin/_base.html" %}
-{% load static %}
-
+{% load static templatetags %}
 {% block form_nav %}
     {% include "respa_admin/resources/form/_nav.html" %}
 {% endblock form_nav %}
-
 {% block body %}
     <div class="container form-container">
-        <form
-            method="post"
-            enctype="multipart/form-data"
-            class="resource-form"
-        >
+        <form method="post" enctype="multipart/form-data" class="resource-form">
             {% csrf_token %}
             {{ resource_accessibility_formset.management_form }}
             {{ resource_image_formset.management_form }}
             {{ period_formset_with_days.management_form }}
-
-            {% include "respa_admin/forms/_form_errors.html" %}
-
+            {% form_errors form resource_image_formset period_formset_with_days resource_accessibility_formset %}
             {% include "respa_admin/resources/form/_general_info.html" %}
             {% include "respa_admin/resources/form/_booking.html" %}
             {% include "respa_admin/resources/form/_images.html" with formset=resource_image_formset %}
@@ -27,16 +19,13 @@
             {% include "respa_admin/resources/form/_equipment.html" %}
             {% include "respa_admin/resources/form/_periods.html" with formset=period_formset_with_days %}
             {% if accessibility_data_link %}
-              {% include "respa_admin/resources/form/_accessibility.html" %}
+                {% include "respa_admin/resources/form/_accessibility.html" %}
             {% endif %}
-
-            <div class="navbar-fixed-bottom">
-                {% include "respa_admin/resources/form/_toolbar.html" %}
-            </div>
+            <div class="navbar-fixed-bottom">{% include "respa_admin/resources/form/_toolbar.html" %}</div>
         </form>
     </div>
 {% endblock body %}
-
 {% block js_extra %}
-    <script type="text/javascript" src="{% static 'respa_admin/resourceForm-bundle.js' %}"></script>
+    <script type="text/javascript"
+            src="{% static 'respa_admin/resourceForm-bundle.js' %}"></script>
 {% endblock js_extra %}

--- a/respa_admin/templates/respa_admin/resources/edit_user.html
+++ b/respa_admin/templates/respa_admin/resources/edit_user.html
@@ -1,22 +1,24 @@
 {% extends "respa_admin/_base.html" %}
 {% load static %}
 {% load i18n %}
-
+{% load templatetags %}
 {% block body %}
-<div class="container form-container">
-    <form method="post" enctype="multipart/form-data" class="resource-form">
-        {% csrf_token %}
-        {% include "respa_admin/forms/_form_errors.html" %}
-        {% include "respa_admin/resources/form/_user_info.html" %}
-        <div class="button-div">
-            <button class="resources-button" type="submit">{% trans "Save" %}</button>
-            <a href="{% url 'respa_admin:user-management' %}" target="_blank" rel="noopener noreferrer">
-                <button class="btn cancel-button" type="button">
-                    {% trans "Cancel" %}
-                </button>
-            </a>
-            <button id='add-new-permission' class="resources-button pull-right" type="button">{% trans "Add permissions" %}</button>
+    <div class="container form-container">
+        <form method="post" enctype="multipart/form-data" class="resource-form">
+            {% csrf_token %}
+            {% form_errors form unit_authorization_formset %}
+                {% include "respa_admin/resources/form/_user_info.html" %}
+                <div class="button-div">
+                    <button class="resources-button" type="submit">{% trans "Save" %}</button>
+                    <a href="{% url 'respa_admin:user-management' %}"
+                       target="_blank"
+                       rel="noopener noreferrer">
+                        <button class="btn cancel-button" type="button">{% trans "Cancel" %}</button>
+                    </a>
+                    <button id="add-new-permission"
+                            class="resources-button pull-right"
+                            type="button">{% trans "Add permissions" %}</button>
+                </div>
+            </form>
         </div>
-    </form>
-</div>
-{% endblock body %}
+    {% endblock body %}

--- a/respa_admin/templates/respa_admin/units/create_unit.html
+++ b/respa_admin/templates/respa_admin/units/create_unit.html
@@ -1,32 +1,22 @@
 {% extends "respa_admin/_base.html" %}
-{% load static %}
-
+{% load static templatetags %}
 {% block form_nav %}
     {% include "respa_admin/units/form/_nav.html" %}
 {% endblock form_nav %}
-
 {% block body %}
     <div class="container form-container">
-        <form
-            method="post"
-            enctype="multipart/form-data"
-            class="resource-form"
-        >
+        <form method="post" enctype="multipart/form-data" class="resource-form">
             {% csrf_token %}
             {{ period_formset_with_days.management_form }}
-
-            {% include "respa_admin/forms/_form_errors.html" %}
-
-            {% include "respa_admin/units/form/_general_info.html" %}
-            {% include "respa_admin/units/form/_unit_settings.html" %}
-            {% include "respa_admin/units/form/_periods.html" with formset=period_formset_with_days %}
-            <div class="navbar-fixed-bottom">
-                {% include "respa_admin/units/form/_toolbar.html" %}
-            </div>
-        </form>
-    </div>
-{% endblock body %}
-
-{% block js_extra %}
-    <script type="text/javascript" src="{% static 'respa_admin/unitForm-bundle.js' %}"></script>
-{% endblock js_extra %}
+            {% form_errors form period_formset_with_days %}
+                {% include "respa_admin/units/form/_general_info.html" %}
+                {% include "respa_admin/units/form/_unit_settings.html" %}
+                {% include "respa_admin/units/form/_periods.html" with formset=period_formset_with_days %}
+                <div class="navbar-fixed-bottom">{% include "respa_admin/units/form/_toolbar.html" %}</div>
+            </form>
+        </div>
+    {% endblock body %}
+    {% block js_extra %}
+        <script type="text/javascript"
+                src="{% static 'respa_admin/unitForm-bundle.js' %}"></script>
+    {% endblock js_extra %}

--- a/respa_admin/templatetags/templatetags.py
+++ b/respa_admin/templatetags/templatetags.py
@@ -1,7 +1,28 @@
+import itertools
 from django import template
 
-
 register = template.Library()
+
+
+@register.inclusion_tag("respa_admin/forms/_form_errors.html")
+def form_errors(*forms):
+    """Renders list of errors from multiple forms or formsets to template."""
+    errors = []
+
+    for form in forms:
+        # may be None etc
+        if not hasattr(form, "errors"):
+            continue
+        # formset: errors will be list of dicts
+        if isinstance(form.errors, list):
+            for dct in form.errors:
+                errors += list(dct.values())
+        # plain form
+        elif isinstance(form.errors, dict):
+            errors += list(form.errors.values())
+    # flatten list
+    errors = list(itertools.chain.from_iterable(errors))
+    return {"errors": errors}
 
 
 @register.filter
@@ -24,7 +45,7 @@ def instances_and_widgets(bound_field):
     for index, instance in enumerate(bound_field.field.queryset.all()):
         widget = copy(bound_field[index])
         # Hide the choice label so it just renders as a checkbox
-        widget.choice_label = ''
+        widget.choice_label = ""
         instance_widgets.append((instance, widget))
     return instance_widgets
 

--- a/respa_admin/tests/test_resource_forms.py
+++ b/respa_admin/tests/test_resource_forms.py
@@ -124,13 +124,29 @@ def test_resource_creation_sets_opening_hours(admin_client, valid_resource_form_
     assert closing_time.minute == 0
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_resource_creation_with_empty_hours(admin_client, valid_resource_form_data):
     resource_count = Resource.objects.count()
     data = valid_resource_form_data.copy()
     data["days-periods-0-0-opens"] = ""
     data["days-periods-0-0-closes"] = ""
     data["days-periods-0-0-closed"] = ""
+    response = admin_client.post(NEW_RESOURCE_URL, data=data, follow=True)
+    assert response.status_code == 200
+    assert (
+        Resource.objects.count() == resource_count
+    ), "No new resource should be created with invalid data"
+
+
+@pytest.mark.django_db
+def test_resource_creation_missing_start_end(admin_client, valid_resource_form_data):
+    resource_count = Resource.objects.count()
+    data = {
+        **valid_resource_form_data,
+        "periods-0-name": "",
+        "periods-0-start": "",
+        "periods-0-end": "",
+    }
     response = admin_client.post(NEW_RESOURCE_URL, data=data, follow=True)
     assert response.status_code == 200
     assert (

--- a/respa_admin/tests/test_templatetags.py
+++ b/respa_admin/tests/test_templatetags.py
@@ -1,0 +1,85 @@
+import pytest
+from django import forms
+from django.utils import translation
+from respa_admin.templatetags.templatetags import form_errors
+
+
+class MyForm(forms.Form):
+    name = forms.CharField(required=True)
+
+
+MyFormSet = forms.formset_factory(MyForm)
+
+
+class TestFormErrors:
+    error_msg = "Tämä kenttä vaaditaan."
+
+    @pytest.fixture()
+    def formset_data(self):
+        return {
+            "form-TOTAL_FORMS": 1,
+            "form-INITIAL_FORMS": 1,
+            "form-MIN_NUM_FORMS": 1,
+            "form-MAX_NUM_FORMS": 1,
+        }
+
+    def test_form_is_none(self):
+        """Any non-form instance should be ignored."""
+        assert form_errors(None) == {"errors": []}
+
+    def test_unbound_form(self):
+        """If not bound, should not be any errors"""
+        assert form_errors(MyForm()) == {"errors": []}
+
+    def test_form_valid(self):
+        """If valid, should not be any errors"""
+        form = MyForm({"name": "ok"})
+        assert form.is_valid()
+        assert form_errors(form) == {"errors": []}
+
+    def test_form_invalid(self):
+        """If invalid, should be an error"""
+        form = MyForm({})
+        assert not form.is_valid()
+
+        with translation.override("fi"):
+            assert form_errors(form) == {"errors": [self.error_msg]}
+
+    def test_unbound_formset(self):
+        """If not bound, should not be any errors"""
+        assert form_errors(MyFormSet()) == {"errors": []}
+
+    def test_formset_valid(self, formset_data):
+        """If valid, should not be any errors"""
+        formset = MyFormSet(
+            {
+                **formset_data,
+                "form-0-name": "ok",
+            }
+        )
+        assert formset.is_valid()
+        assert form_errors(formset) == {"errors": []}
+
+    def test_formset_invalid(self, formset_data):
+        """If invalid, should be an error"""
+        formset = MyFormSet(formset_data)
+        assert not formset.is_valid()
+
+        with translation.override("fi"):
+            assert form_errors(formset) == {"errors": [self.error_msg]}
+
+    def test_formset_and_form_invalid(self, formset_data):
+        """Should render all form errors"""
+        form = MyForm({})
+        formset = MyFormSet(formset_data)
+
+        assert not form.is_valid()
+        assert not formset.is_valid()
+
+        with translation.override("fi"):
+            assert form_errors(form, formset) == {
+                "errors": [
+                    self.error_msg,
+                    self.error_msg,
+                ]
+            }

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -439,7 +439,12 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
                 self._save_resource_accessibility(resource_accessibility_formset)
         except ValidationError:
             messages.error(self.request, _("Please check the opening hours"))
-            return self.form_invalid(form)
+            return self.forms_invalid(
+                form,
+                period_formset_with_days,
+                resource_image_formset,
+                resource_accessibility_formset,
+            )
 
         return HttpResponseRedirect(self.get_success_url())
 
@@ -482,17 +487,22 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
     def _validate_forms(
         self, form, period_formset, image_formset, resource_accessibility_formset
     ):
-        valid_form = form.is_valid()
-        valid_period_form = period_formset.is_valid()
-        valid_image_formset = image_formset.is_valid()
-        valid_resource_accessibility_formset = resource_accessibility_formset.is_valid()
+        try:
+            valid_form = form.is_valid()
+            valid_period_form = period_formset.is_valid()
+            valid_image_formset = image_formset.is_valid()
+            valid_resource_accessibility_formset = (
+                resource_accessibility_formset.is_valid()
+            )
 
-        return (
-            valid_form
-            and valid_period_form
-            and valid_image_formset
-            and valid_resource_accessibility_formset
-        )
+            return (
+                valid_form
+                and valid_period_form
+                and valid_image_formset
+                and valid_resource_accessibility_formset
+            )
+        except ValidationError:
+            return False
 
     def _save_resource_purposes(self):
         checked_purposes = self.request.POST.getlist("purposes")

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -386,8 +386,6 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
             request=request, instance=self.object
         )
 
-        period_template_formset = get_period_template_formset()
-
         if self._validate_forms(
             form,
             period_formset_with_days,
@@ -404,7 +402,6 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
             return self.forms_invalid(
                 form,
                 period_formset_with_days,
-                period_template_formset,
                 resource_image_formset,
                 resource_accessibility_formset,
             )
@@ -452,7 +449,6 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
         self,
         form,
         period_formset_with_days,
-        period_template_formset,
         resource_image_formset,
         resource_accessibility_formset,
     ):
@@ -476,7 +472,7 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
             self.get_context_data(
                 form=form,
                 period_formset_with_days=period_formset_with_days,
-                period_template_formset=period_template_formset,
+                period_template_formset=get_period_template_formset(),
                 resource_image_formset=resource_image_formset,
                 resource_accessibility_formset=resource_accessibility_formset,
                 trans_fields=trans_fields,

--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib import messages
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import FieldDoesNotExist, Q
 from django.forms import model_to_dict
@@ -424,14 +425,22 @@ class SaveResourceView(ExtraContextMixin, PeriodMixin, CreateView):
         resource_image_formset,
         resource_accessibility_formset,
     ):
-        self.object = form.save()
-        self._save_resource_purposes()
-        self._delete_extra_images(resource_image_formset)
-        self._save_resource_images(resource_image_formset)
-        self.save_period_formset(period_formset_with_days)
-        self._save_or_update_opening_hours_via_period_templates()
-        self._delete_extra_resource_accessibility(resource_accessibility_formset)
-        self._save_resource_accessibility(resource_accessibility_formset)
+        try:
+            with transaction.atomic():
+                self.object = form.save()
+                self._save_resource_purposes()
+                self._delete_extra_images(resource_image_formset)
+                self._save_resource_images(resource_image_formset)
+                self.save_period_formset(period_formset_with_days)
+                self._save_or_update_opening_hours_via_period_templates()
+                self._delete_extra_resource_accessibility(
+                    resource_accessibility_formset
+                )
+                self._save_resource_accessibility(resource_accessibility_formset)
+        except ValidationError:
+            messages.error(self.request, _("Please check the opening hours"))
+            return self.form_invalid(form)
+
         return HttpResponseRedirect(self.get_success_url())
 
     def forms_invalid(


### PR DESCRIPTION
https://andersinno.atlassian.net/jira/software/c/projects/TTVA/boards/11?modal=detail&selectedIssue=TTVA-136

Misconfigured formset (e.g. `TOTAL_FORMS` invalid due to JS removing a form before user re-submits) may raise a `ValidationError` outside the validation cycle, so a 500 Server Error is returned to the user instead for the form page. This change captures the error and displays an error message.

In addition, individual form errors displayed at the top of the page have been tidied up using a template tag to ensure the errors are rendered in a single list.

![Screenshot from 2023-07-07 11-39-24](https://github.com/andersinno/respa/assets/131681805/87019be0-0efd-4f71-9e7b-f260598a2fc0)
