### PR TITLE
CeePos: Use resource name in order line description (TTVA-150)

### DIFF
--- a/payments/providers/cpu_ceepos.py
+++ b/payments/providers/cpu_ceepos.py
@@ -143,6 +143,10 @@ class CPUCeeposProvider(PaymentProvider):
             resource = order.reservation.resource
             return resource.unit.cost_center_code
 
+        def _get_order_line_description(order: Order) -> str:
+            resource = order.reservation.resource
+            return resource.name
+
         def _get_ceepos_tax_code(order_line: OrderLine) -> str:
             tax_pct = order_line.tax_percentage
             ceepos_tax_codes = {
@@ -174,7 +178,7 @@ class CPUCeeposProvider(PaymentProvider):
                     "Code": _get_ceepos_product_code(order),
                     "Amount": order_line.quantity,
                     "Price": price_as_sub_units(order_line.total_price),
-                    "Description": order_line.product.name,
+                    "Description": _get_order_line_description(order),
                     "Taxcode": _get_ceepos_tax_code(order_line)
                 }
             )


### PR DESCRIPTION
Use the resource's name instead of the product's name as the order line description in the CeePos integration. The order line description is visible to the orderer when they make the payment in CeePos.

When the resource name is changed, the related products' names are not updated automatically. This lead to the order line description being incorrect in Ceepos in such cases.

![Screenshot 2023-08-11 at 12 58 01](https://github.com/andersinno/respa/assets/5648062/4f2a3691-3d8d-428f-a0c1-ba99be22c03a)


Refs TTVA-150