### PR TITLE
Pin django-tamusers dependency to latest commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 --no-binary psycopg2
 
-git+https://github.com/Tampere/django-tamusers.git@3b93b96cacb4a9cb07a8e932dd5c3a8aa465dfc4#egg=django-tamusers
+git+https://github.com/Tampere/django-tamusers.git@9eb5f84171b1a2f525f28de408171608dd122574#egg=django-tamusers
 arrow==0.13.0             # via -r requirements.in
 asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.2.1       # via pytest


### PR DESCRIPTION
This change pins the requirements to the latest commit, which should include upstream fixes on django-tamusers.

In particular this should handle the issues outlined here:

https://andersinno.atlassian.net/jira/software/c/projects/TTVA/boards/12?selectedIssue=TTVA-173