### PR TITLE
Save invoicing specific fields to reservation (TTVA-179)

### DIFF
--- a/payments/tests/test_reservation_api.py
+++ b/payments/tests/test_reservation_api.py
@@ -844,6 +844,7 @@ def test_request_invoice(
         "type": reservation_type,
         "invoice_requested": True,
         "reserver_id": "ABC-123",
+        "company": "Company AB",
         "company_address_street": "Street 123",
         "company_address_city": "Helsinki",
         "company_address_zip": "12345",

--- a/payments/tests/test_reservation_api.py
+++ b/payments/tests/test_reservation_api.py
@@ -843,6 +843,10 @@ def test_request_invoice(
         **build_reservation_data(paid_resource),
         "type": reservation_type,
         "invoice_requested": True,
+        "reserver_id": "ABC-123",
+        "company_address_street": "Street 123",
+        "company_address_city": "Helsinki",
+        "company_address_zip": "12345",
     }
 
     product = ProductFactory(type=Product.RENT, resources=[paid_resource])

--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -29,7 +29,7 @@ from rest_framework.settings import api_settings as drf_settings
 
 from payments.providers import get_payment_provider
 from resources.models import Reservation, ReservationMetadataSet, Resource
-from resources.models.reservation import RESERVATION_EXTRA_FIELDS
+from resources.models.reservation import RESERVATION_EXTRA_FIELDS, RESERVATION_INVOICING_FIELDS
 from resources.models.utils import (
     generate_reservation_csv,
     generate_reservation_xlsx,
@@ -138,17 +138,17 @@ class ReservationSerializer(
             # staff events have less requirements
             request_user = self.context["request"].user
             is_staff_event = data.get("staff_event", False)
+            invoice_requested = data.get("invoice_requested", False)
+
+            # Fields required when payment by invoice is requested.
+            # These might not be in the metadata set, so we need to
+            # include them here.
+            invoicing_specific_fields = set(RESERVATION_INVOICING_FIELDS)
 
             required = resource.get_required_reservation_extra_field_names(cache=cache)
 
-            if data.get("invoice_requested", False):
-                required = set(required) | {
-                    "reserver_id",
-                    "company_address",
-                    "company_address_street",
-                    "company_address_zip",
-                    "company_address_city",
-                }
+            if invoice_requested:
+                required = set(required) | invoicing_specific_fields
 
             # staff events always have the same set of required fields
             if is_staff_event and resource.can_create_staff_event(request_user):
@@ -177,6 +177,9 @@ class ReservationSerializer(
             supported = resource.get_supported_reservation_extra_field_names(
                 cache=cache
             )
+
+            if invoice_requested:
+                supported = set(supported) | invoicing_specific_fields
 
             for field_name in supported:
                 if field_name in self.fields:
@@ -391,6 +394,10 @@ class ReservationSerializer(
             supported_fields = set(
                 resource.get_supported_reservation_extra_field_names(cache=cache)
             )
+            # Always include the fields that are required for invoiceable
+            # reservations, as they might not be in the metadata set. Otherwise PUT
+            # requests would fail due to the fields missing from the data.
+            supported_fields = supported_fields | set(RESERVATION_INVOICING_FIELDS)
         else:
             supported_fields = set()
 

--- a/resources/models/__init__.py
+++ b/resources/models/__init__.py
@@ -1,6 +1,6 @@
 from .accessibility import AccessibilityValue, AccessibilityViewpoint, ResourceAccessibility, UnitAccessibility
 from .availability import Day, Period, get_opening_hours
-from .reservation import ReservationMetadataField, ReservationMetadataSet, Reservation, RESERVATION_EXTRA_FIELDS
+from .reservation import ReservationMetadataField, ReservationMetadataSet, Reservation, RESERVATION_EXTRA_FIELDS, RESERVATION_INVOICING_FIELDS
 from .resource import (
     Purpose, Resource, ResourceType, ResourceImage, ResourceEquipment, ResourceGroup,
     ResourceDailyOpeningHours, TermsOfUse
@@ -19,6 +19,7 @@ __all__ = [
     'Period',
     'Purpose',
     'RESERVATION_EXTRA_FIELDS',
+    'RESERVATION_INVOICING_FIELDS',
     'Reservation',
     'ReservationMetadataField',
     'ReservationMetadataSet',

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -73,6 +73,15 @@ RESERVATION_EXTRA_FIELDS = (
     "reservation_extra_questions",
 )
 
+# Fields required when payment by invoice is requested.
+RESERVATION_INVOICING_FIELDS = (
+    "reserver_id",
+    "company_address",
+    "company_address_street",
+    "company_address_zip",
+    "company_address_city",
+)
+
 
 class ReservationQuerySet(models.QuerySet):
     def current(self):

--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -76,6 +76,7 @@ RESERVATION_EXTRA_FIELDS = (
 # Fields required when payment by invoice is requested.
 RESERVATION_INVOICING_FIELDS = (
     "reserver_id",
+    "company",
     "company_address",
     "company_address_street",
     "company_address_zip",

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -28,6 +28,7 @@ from resources.models import (
     Resource,
     ResourceGroup,
     UnitAuthorization,
+    RESERVATION_INVOICING_FIELDS,
 )
 
 from .utils import (
@@ -1055,7 +1056,10 @@ def test_extra_fields_visibility(
         reservation_data = (
             response.data["results"][0] if "results" in response.data else response.data
         )
-        for field_name in DEFAULT_RESERVATION_EXTRA_FIELDS:
+        # The invoicing specific fields should be always present, regardless of whether
+        # manual confirmation is needed ot not, so we don't want to test those here.
+        fields = set(DEFAULT_RESERVATION_EXTRA_FIELDS) - set(RESERVATION_INVOICING_FIELDS)
+        for field_name in fields:
             assert (field_name in reservation_data) is need_manual_confirmation
 
 


### PR DESCRIPTION
When payment by invoice is requested, we require certain fields to be present in the reservation data. However, these fields are not saved to the `Reservation` object unless the fields are also included in the metadata set. That is not the case when the customer wants to show those fields only when payment by invoice is requested.

Make sure the invoicing specific fields are required and saved even if they aren't included in the metadata set, when invoice is requested.

Refs TTVA-179