### PR TITLE
Respa admin: List only confirmed reservations in invoiceables (TTVA-180)

### DIFF
--- a/respa_admin/views/reservations.py
+++ b/respa_admin/views/reservations.py
@@ -31,7 +31,9 @@ class InvoiceableReservationListView(ExtraContextMixin, ListView):
     def get_queryset(self):
         managed_resources = Resource.objects.modifiable_by(self.request.user)
         qs = Reservation.objects.filter(
-            invoice_approved_at__isnull=False, resource__in=managed_resources
+            state=self.model.CONFIRMED,
+            invoice_approved_at__isnull=False,
+            resource__in=managed_resources
         ).select_related("order", "resource")
 
         if self.search_query:


### PR DESCRIPTION
List confirmed reserarvations only in the Invoiceable Reservations list in Respa Admin. It doesn't make sense to list cancelled reservations there.

Refs TTVA-180