### PR TITLE
Resource form height fix

### DIFF
--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -254,6 +254,10 @@ class ResourceAccess(models.Model):
 
     access_method = models.CharField(max_length=15, choices=ACCESS_METHODS, unique=True)
 
+    class Meta:
+        verbose_name = _("Resource access method")
+        verbose_name_plural = _("Resource access methods")
+
     def __str__(self):
         return self.get_access_method_display()
 

--- a/respa_admin/static_src/styles/form/page-form.scss
+++ b/respa_admin/static_src/styles/form/page-form.scss
@@ -14,6 +14,10 @@
 .form-container {
   padding-bottom: $input-height-default + $padding-large-vertical * 2;
 
+  &-resource {
+    padding-bottom: $input-height-default + $padding-large-vertical * 1.5;
+  }
+
   .error, .success {
     width: 100%;
   }
@@ -148,3 +152,5 @@
     color: red;
   }
 }
+
+

--- a/respa_admin/templates/respa_admin/resources/create_resource.html
+++ b/respa_admin/templates/respa_admin/resources/create_resource.html
@@ -4,7 +4,7 @@
     {% include "respa_admin/resources/form/_nav.html" %}
 {% endblock form_nav %}
 {% block body %}
-    <div class="container form-container">
+    <div class="container form-container form-container-resource">
         <form method="post" enctype="multipart/form-data" class="resource-form">
             {% csrf_token %}
             {{ resource_accessibility_formset.management_form }}


### PR DESCRIPTION
Reduces the default bottom padding of Resource forms,  which appears to fix the issue of triggering the above/below behaviour of the Period template dropdown widget when there are no periods added to the Resource.

This does not touch the default padding of other Respa admin forms, if issue appears elsewhere we should look for a better fix.

Note: this PR also fixes the missing verbose names for Resource access methods so they match the correct translations in Django admin.

![Screenshot from 2023-12-21 15-18-45](https://github.com/andersinno/respa/assets/131681805/d6068a0f-1ac0-4b2d-9e0e-32a9b2464495)
