### PR TITLE
Resources: change Resource.objects.free_of_charge() logic

### DIFF
--- a/resources/models/resource.py
+++ b/resources/models/resource.py
@@ -215,32 +215,10 @@ class ResourceQuerySet(models.QuerySet):
         )
 
     def free_of_charge(self, is_free):
-        """if `is_free` is True, returns any resources that either have
-        `free_to_use=True` or have no associated price lists with amounts > zero.
-
-        Otherwise returns any resources that have prices attached
-        and `free_to_use` is False.
+        """if `is_free` is True, returns resource with `free_to_use` is True,
+        else returns all those with `free_to_use` is False.
         """
-        queryset = self.annotate(
-            has_pricing=models.Exists(
-                self.filter(
-                    Q(default_min_price__gt=0)
-                    | Q(default_max_price__gt=0)
-                    | Q(
-                        products__pricedproduct__price_list__usergroup_prices__price__gt=0,
-                    )
-                    | Q(
-                        products__pricedproduct__price_list__event_prices__price__gt=0,
-                    ),
-                    pk=models.OuterRef("pk"),
-                )
-            )
-        )
-
-        if is_free:
-            return queryset.filter(Q(free_to_use=True) | Q(has_pricing=False))
-        else:
-            return queryset.filter(free_to_use=False, has_pricing=True)
+        return self.filter(free_to_use=is_free)
 
 
 class ResourceAccess(models.Model):

--- a/resources/tests/test_resource.py
+++ b/resources/tests/test_resource.py
@@ -61,7 +61,7 @@ def test_get_reservable_before_not_none():
 
 
 @pytest.mark.django_db
-def test_free_of_charge_free_to_use_true_no_pricing_info(space_resource):
+def test_free_of_charge_free_to_use_true(space_resource):
     space_resource.free_to_use = True
     space_resource.save()
 
@@ -70,87 +70,12 @@ def test_free_of_charge_free_to_use_true_no_pricing_info(space_resource):
 
 
 @pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_has_default_min_price(space_resource):
+def test_free_of_charge_free_to_use_false(space_resource):
     space_resource.free_to_use = False
-    space_resource.default_min_price = Decimal("10.00")
     space_resource.save()
 
-    assert Resource.objects.free_of_charge(True).count() == 0
     assert Resource.objects.free_of_charge(False).count() == 1
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_has_default_max_price(space_resource):
-    space_resource.free_to_use = False
-    space_resource.default_min_price = Decimal("0")
-    space_resource.default_max_price = Decimal("10.00")
-    space_resource.save()
-
     assert Resource.objects.free_of_charge(True).count() == 0
-    assert Resource.objects.free_of_charge(False).count() == 1
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_has_default_min_max_price(space_resource):
-    space_resource.free_to_use = False
-    space_resource.default_min_price = Decimal("10.00")
-    space_resource.default_max_price = Decimal("20.00")
-    space_resource.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 0
-    assert Resource.objects.free_of_charge(False).count() == 1
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_has_default_min_price_zero(space_resource):
-    space_resource.free_to_use = False
-    space_resource.default_min_price = Decimal("0")
-    space_resource.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 1
-    assert Resource.objects.free_of_charge(False).count() == 0
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_has_default_min_price_null(space_resource):
-    space_resource.free_to_use = False
-    space_resource.default_min_price = None
-    space_resource.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 1
-    assert Resource.objects.free_of_charge(False).count() == 0
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_true_has_default_min_price_gt_zero(space_resource):
-    space_resource.free_to_use = True
-    space_resource.default_min_price = Decimal("10.00")
-    space_resource.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 1
-    assert Resource.objects.free_of_charge(False).count() == 0
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_true_has_default_max_price_gt_zero(space_resource):
-    space_resource.free_to_use = True
-    space_resource.default_max_price = Decimal("10.00")
-    space_resource.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 1
-    assert Resource.objects.free_of_charge(False).count() == 0
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_no_pricing_info(space_resource):
-    """Even if free_to_use is False, is still free of charge as there is
-    no pricing info attached."""
-
-    space_resource.free_to_use = False
-    space_resource.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 1
-    assert Resource.objects.free_of_charge(False).count() == 0
 
 
 @pytest.mark.django_db
@@ -211,62 +136,6 @@ def test_free_of_charge_free_to_use_true_with_pricing_info(
 
     assert Resource.objects.free_of_charge(True).count() == 1
     assert Resource.objects.free_of_charge(False).count() == 0
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_with_pricing_info_zero(
-    space_resource_with_product, priced_product
-):
-    """If pricing is available but is zero, then should still be free of charge."""
-    UserGroupPriceListItemFactory(price_list=priced_product.price_list, price="00.00")
-
-    space_resource_with_product.free_to_use = False
-    space_resource_with_product.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 1
-    assert Resource.objects.free_of_charge(False).count() == 0
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_with_user_group_pricing_info(
-    space_resource_with_product, priced_product
-):
-    UserGroupPriceListItemFactory(price_list=priced_product.price_list, price="100.00")
-
-    space_resource_with_product.free_to_use = False
-    space_resource_with_product.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 0
-    assert Resource.objects.free_of_charge(False).count() == 1
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_with_event_type_pricing_info(
-    space_resource_with_product, priced_product
-):
-    EventTypePriceListItemFactory(price_list=priced_product.price_list, price="100.00")
-
-    space_resource_with_product.free_to_use = False
-    space_resource_with_product.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 0
-    assert Resource.objects.free_of_charge(False).count() == 1
-
-
-@pytest.mark.django_db
-def test_free_of_charge_free_to_use_false_with_mixed_pricing_info(
-    space_resource_with_product, priced_product
-):
-    """Check combination of different prices"""
-    UserGroupPriceListItemFactory(price_list=priced_product.price_list, price="0.00")
-    UserGroupPriceListItemFactory(price_list=priced_product.price_list, price="5.00")
-    EventTypePriceListItemFactory(price_list=priced_product.price_list, price="100.00")
-
-    space_resource_with_product.free_to_use = False
-    space_resource_with_product.save()
-
-    assert Resource.objects.free_of_charge(True).count() == 0
-    assert Resource.objects.free_of_charge(False).count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Previously the implementation would consider "free" to be:

1) Has "free_to_use" value True
2) Does not have a price list (internal payments)
3) Does not have min/max default prices (external payments)

A resource that did not match 2) and 3) but still had free_to_use=False would still be considered "free".

The logic is now that any resource with free_to_use=True is free, and all others are considered paid resources, even though there is no attached pricing information.

In addition this commit removes associated unit tests as the use cases are much simpler.

![Screenshot from 2023-12-28 13-33-05](https://github.com/andersinno/respa/assets/131681805/7e0a05b3-ca91-4191-85ef-5f14375c88ef)
