### PR TITLE
Fixes to the XLSX/CSV report exports (TTVA-191)

### DIFF
--- a/resources/api/reservation.py
+++ b/resources/api/reservation.py
@@ -431,14 +431,12 @@ class ReservationSerializer(
             "state": instance.get_state_display(),
         }
 
-        if request.data.get("includeAccountingFields") == "1":
+        if request.query_params.get("includeAccountingFields") == "1":
             order = instance.get_order()
             if order:
                 price = order.get_price()
                 if price:
                     order_line = order.order_lines.first()
-                    user_group = order_line.user_group if order_line else None
-                    event_type = order_line.event_type if order_line else None
 
                     data = {
                         **data,
@@ -447,11 +445,9 @@ class ReservationSerializer(
                         "sap_cost_center_code": instance.resource.unit.sap_cost_center_code,
                         "sap_sales_organization": instance.resource.unit.sap_sales_organization,
                         "invoice_generated_at": instance.invoice_generated_at,
-                        "tax_percentage": order.tax_percentage,
-                        "quantity": order.quantity,
-                        "unit_price": order.unit_price,
-                        "user_group": user_group,
-                        "event_type": event_type,
+                        "tax_percentage": order_line.tax_percentage if order_line else None,
+                        "quantity": order_line.quantity if order_line else None,
+                        "unit_price": order_line.unit_price if order_line else None,
                     }
         return data
 

--- a/resources/models/utils.py
+++ b/resources/models/utils.py
@@ -32,16 +32,14 @@ RESERVATION_FIELDS = [
 ]
 
 RESERVATION_ACCOUNTING_FIELDS = [
-    ("user_group", "User group", 15),
-    ("event_type", "Event type", 15),
     ("quantity", "Quantity", 15),
     ("unit_price", "Unit price", 15),
     ("total_price", "Total price", 15),
+    ("tax_percentage", "Tax percentage", 15),
     ("cost_center_code", "CeePos Cost center code", 30),
     ("sap_cost_center_code", "SAP Cost center code", 30),
     ("sap_sales_organization", "SAP Sales Organization code", 30),
     ("invoice_generated_at", "Invoice created", 15),
-    ("tax_percentage", "Tax percentage", 15),
 ]
 
 RESERVATION_DATETIME_FIELDS = [

--- a/resources/pagination.py
+++ b/resources/pagination.py
@@ -3,7 +3,9 @@ from rest_framework.pagination import PageNumberPagination, _positive_int
 
 class DefaultPagination(PageNumberPagination):
     page_size = 20
-    page_size_query_param = 'page_size'  # Allow client to override, using `?page_size=xxx
+    page_size_query_param = (
+        "page_size"  # Allow client to override, using `?page_size=xxx
+    )
     max_page_size = 500
 
 
@@ -15,12 +17,18 @@ class ReservationPagination(DefaultPagination):
     def get_page_size(self, request):
         if self.page_size_query_param:
             cutoff = self.max_page_size
-            if request.query_params.get('format', '').lower() == 'xlsx':
+            if request.query_params.get("format", "").lower() == "xlsx":
+                cutoff = 50000
+            if request.accepted_media_type in [
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "text/csv",
+            ]:
                 cutoff = 50000
             try:
                 return _positive_int(
                     request.query_params[self.page_size_query_param],
-                    strict=True, cutoff=cutoff
+                    strict=True,
+                    cutoff=cutoff,
                 )
             except (KeyError, ValueError):
                 pass


### PR DESCRIPTION
**Fix the accounting report**

- Read the `includeAccountingFields` from the query params instead
of the request data.
- Remove the user group and event type fields from the report since
we don't have this data saved to the order/reservation. Additional changed
are needed if this data is required in reports.
- Get the prices and tax percentage from the order line instead of the order.

**Allow bigger page size for the reservation report exports**

Set the limit to 50000 records instead of the 500 limit maximum. This affects all the XLSX/CSV exports.