### PR TITLE
TTVA-200 | Allow new reservation time to overlap with original time

### DIFF
--- a/resources/models/reservation.py
+++ b/resources/models/reservation.py
@@ -709,6 +709,11 @@ class Reservation(ModifiableModel):
             valid_reservations_for_same_unit = reservations_for_same_unit.exclude(
                 state=Reservation.CANCELLED
             )
+            # Exclude current reservation from the valid_reservations_for_same_unit list to allow user to 
+            # update reservation if new times overlaps only with the original times of the same reservation
+            if original_reservation := kwargs.get("original_reservation", None):
+                valid_reservations_for_same_unit = valid_reservations_for_same_unit.exclude(id=original_reservation.id)
+
             user_has_conflicting_reservations = valid_reservations_for_same_unit.filter(
                 Q(begin__gt=self.begin, begin__lt=self.end)
                 | Q(begin__lt=self.begin, end__gt=self.begin)

--- a/resources/tests/test_reservation_api.py
+++ b/resources/tests/test_reservation_api.py
@@ -546,6 +546,19 @@ def test_reservation_can_be_modified_by_overlapping_reservation(
     assert reservation.begin == dateparse.parse_datetime("2115-04-04T09:00:00+02:00")
     assert reservation.end == dateparse.parse_datetime("2115-04-04T11:00:00+02:00")
 
+    # Set disallow_overlapping_reservations to True and test updating reservation times again
+    reservation.resource.unit.disallow_overlapping_reservations = True
+    reservation.resource.unit.save()
+
+    # try to move the original reservation to start 1 hour later
+    reservation_data["begin"] = "2115-04-04T10:00:00+02:00"
+    reservation_data["end"] = "2115-04-04T12:00:00+02:00"
+    response = api_client.put(detail_url, reservation_data)
+    assert response.status_code == 200
+    reservation = Reservation.objects.get(pk=reservation.pk)
+    assert reservation.begin == dateparse.parse_datetime("2115-04-04T10:00:00+02:00")
+    assert reservation.end == dateparse.parse_datetime("2115-04-04T12:00:00+02:00")
+
 
 @pytest.mark.parametrize("perm_type", ["unit", "resource_group"])
 @pytest.mark.django_db


### PR DESCRIPTION
## Description
Allow updated reservation times to overlap with the original times also in the case that disallow_overlapping_reservations is set to True in the resource unit of the reservation