### PR TITLE
Securitas Flow: Use email address from reservation (TTVA-214)

### DIFF
--- a/kulkunen/drivers/securitas.py
+++ b/kulkunen/drivers/securitas.py
@@ -43,6 +43,7 @@ class SecuritasDriver(AccessControlDriver):
         assert grant.state == grant.INSTALLING
 
         user = grant.reservation.user
+        email = grant.reservation.reserver_email_address or user.email
 
         user_id = str(user.pk)
 
@@ -65,7 +66,7 @@ class SecuritasDriver(AccessControlDriver):
                 "userExtId": user_id,
                 "firstName": user.first_name,
                 "lastName": user.last_name,
-                "email": user.email,
+                "email": email,
                 "notifyUser": True,
                 **params,
             },


### PR DESCRIPTION
When creating the access grants for Securitas Flow, use the email address from the reservation first and fall back to the user's email address if the reservation doesn't have the reserver email address specified (i.e. it's not asked in the reservation form).

Refs TTVA-214