### PR TITLE
TTVA-217 | Hide people_capacity_upper from the Respa admin

### DIFF
--- a/respa_admin/templates/respa_admin/resources/form/_booking.html
+++ b/respa_admin/templates/respa_admin/resources/form/_booking.html
@@ -7,7 +7,6 @@
     </div>
     <div class="input-row">
         {% include "respa_admin/forms/_input.html" with field=form.people_capacity_lower %}
-        {% include "respa_admin/forms/_input.html" with field=form.people_capacity_upper %}
         {% include "respa_admin/forms/_input.html" with field=form.area %}
     </div>
     <div class="input-row dropdown-row">


### PR DESCRIPTION
Hide the `people_capacity_upper` field from the Respa admin's resource form for now.

Waiting for new label and help texts for the fields.

TTVA-217