### PR TITLE
STAM-36 | Remove Guardian permissions when unit authorization is deleted

### DIFF
--- a/respa_admin/views/resources.py
+++ b/respa_admin/views/resources.py
@@ -118,8 +118,17 @@ class ManageUserPermissionsView(ExtraContextMixin, DetailView):
 
     def forms_valid(self, unit_authorization_formset):
         unit_authorization_formset.instance = self.object
+        
+        # Handle deleted forms - remove permissions for deleted authorizations
+        for form in unit_authorization_formset.deleted_forms:
+            if form.cleaned_data.get("subject"):
+                remove_perm(
+                    "unit:can_approve_reservation", self.object, form.cleaned_data["subject"]
+                )
+        
+        # Handle existing and new forms
         for form in unit_authorization_formset.cleaned_data:
-            if "subject" in form and "level" in form:
+            if "subject" in form and "level" in form and not form.get("DELETE"):
                 if form["can_approve_reservation"]:
                     assign_perm(
                         "unit:can_approve_reservation", self.object, form["subject"]


### PR DESCRIPTION
## Description
When a unit authorization row is completely removed from the formset, the Guardian permission "unit:can_approve_reservation" was not being removed from the database, leaving orphaned permissions.

This fix adds handling for deleted forms by:
- Processing formset.deleted_forms to remove permissions for deleted authorizations
- Adding DELETE check to skip deleted forms in the main processing loop

## Closes
[STAM-36](https://andersinno.atlassian.net/browse/STAM-36)
